### PR TITLE
Typed support for $in for table columns of type map

### DIFF
--- a/src/DataStax.AstraDB.DataApi/Core/Query/FilterBuilder.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/Query/FilterBuilder.cs
@@ -329,20 +329,6 @@ public class FilterBuilder<T>
     /// </summary>
     /// <typeparam name="TKey">The type of the dictionary keys</typeparam>
     /// <typeparam name="TValue">The type of the dictionary values</typeparam>
-    /// <param name="expression">An expression that represents the dictionary field for this filter</param>
-    /// <param name="pairs">Array of key-value pairs as tuples</param>
-    /// <returns>The filter</returns>
-    public Filter<T> In<TKey, TValue>(Expression<Func<T, Dictionary<TKey, TValue>>> expression, (TKey, TValue)[] pairs)
-    {
-        var pairArrays = pairs.Select(p => new object[] { p.Item1, p.Item2 }).ToArray();
-        return new Filter<T>(expression.GetMemberNameTree(), FilterOperator.In, pairArrays);
-    }
-
-    /// <summary>
-    /// In operator -- Match one or more key-value pairs in a dictionary field.
-    /// </summary>
-    /// <typeparam name="TKey">The type of the dictionary keys</typeparam>
-    /// <typeparam name="TValue">The type of the dictionary values</typeparam>
     /// <param name="fieldName">The name of the field for this filter</param>
     /// <param name="pairs">Array of key-value pairs as tuples</param>
     /// <returns>The filter</returns>

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdditionalTableTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdditionalTableTests.cs
@@ -186,8 +186,8 @@ public class AdditionalTableTests
                     Id = i,
                     StringDictionary = new Dictionary<string, string>
                     {
-                        { "KeyA", "ValueA" },
-                        { "KeyB", "ValueB" }
+                        { "KeyA", $"ValueA {100 + i}" },
+                        { "KeyB", $"ValueB {100 + i}" }
                     },
                     IntDictionary = new Dictionary<string, int>
                     {
@@ -245,6 +245,54 @@ public class AdditionalTableTests
             Assert.NotNull(updatedDocument);
             Assert.Single(updatedDocument.IntKey);
             Assert.Equal(32, updatedDocument.IntKey.Keys.First());
+
+            // Tuple-based dictionary $in filtering (typed):
+            var filterBuilder = Builders<DictionaryTypeTest>.TableFilter;
+
+            var filterIn1 = filterBuilder.In(
+                b => b.StringDictionary,
+                new[] {("KeyA", "ValueA 104"), ("KeyB", "ValueA ZZZ")}
+            );
+            var rowIn1 = await table.FindOneAsync(filterIn1);
+            Assert.NotNull(rowIn1);
+            Assert.Equal(rowIn1.Id, 4);
+
+            var filterIn2 = filterBuilder.In(
+                b => b.IntKey,
+                new[] {(14, "IntValue 4A"), (999, "IntValue ZZZ")}
+            );
+            var rowIn2 = await table.FindOneAsync(filterIn2);
+            Assert.NotNull(rowIn2);
+            Assert.Equal(rowIn2.Id, 4);
+
+            // Tuple-based dictionary $in filtering (untyped):
+            var tableUntyped = fixture.Database.GetTable(tableName);
+            var filterBuilderUntyped = Builders<Row>.TableFilter;
+
+            var filterInUntyped1 = filterBuilderUntyped.In(
+                "StringDictionary",
+                new[]
+                {
+                    // tuples also work (see next filter with heterogeneous key/values)
+                    new[] { "KeyA", "ValueA 104" },
+                    new[] { "KeyB", "ValueA ZZZ" },
+                }
+            );
+            var rowInUntyped1 = await tableUntyped.FindOneAsync(filterInUntyped1);
+            Assert.NotNull(rowInUntyped1);
+            Assert.Equal(((System.Text.Json.JsonElement)rowInUntyped1["Id"]).GetInt32(), 4);
+
+            var filterInUntyped2 = filterBuilderUntyped.In(
+                "IntKey",
+                new[]
+                {
+                    (  14, "IntValue 4A" ),
+                    ( 999, "IntValue ZZZ" ),
+                }
+            );
+            var rowInUntyped2 = await tableUntyped.FindOneAsync(filterInUntyped2);
+            Assert.NotNull(rowInUntyped2);
+            Assert.Equal(((System.Text.Json.JsonElement)rowInUntyped2["Id"]).GetInt32(), 4);
 
         }
         catch (Exception ex)


### PR DESCRIPTION
This PR adds support for filtering with `$in` (aka the method `In` of `FilterBuilder`) for the specific case of querying a map column of a table in a typed setup.

## Problem statement

### Setup 1

Suppose you have (CQL)

```
create table t(title text primary key, metadata map<text,text>);
insert into t(title,metadata) values ('Le Loup', {'language':'French','edition': 'Illustrated Edition'});
```

Now, a valid Data API filter to retrieve this row is the following:

```
{"metadata":{"$in":[["language","French"],["edition","Illustrated Edition"]]}}
```

### Untyped baseline (works on main already)

```
    [Fact()]
    public async Task SteoFBuildersTableUntypedInTest()
    {
        var filterBuilder = Builders<Row>.Filter;
        var filter = filterBuilder.In(
        "metadata",
        new[]
        {
            new[] { "language", "French" },
            new[] { "edition", "Illustrated Edition" },
        }
        );

        var t = fixture.Database.GetTable("t");
        var row = await t.FindOneAsync(filter);
        Assert.NotNull(row);
        Assert.Equal(((System.Text.Json.JsonElement)row["title"]).GetString(), "Le Loup");
    }
```

A list-of lists, `"metadata"` as string, no questions asked, proper payload generated.

### Problem with current main in a typed setup

There is no proper overload of `In` for the case with a dictionary column: the compiler tries to look for the wrong type combination in an expression like this:

```
        var filter = filterBuilder.In(
            b => b.Metadata,
            new[]
            {
                new[] { "language", "French" },
                new[] { "edition", "Illustrated Edition" },
            }
        );
```

One gets a compiler error `Cannot implicitly convert type 'System.Collections.Generic.Dictionary<string, string>' to 'string[][][]`.

## Solution

A new `In` method overload which accepts maps _to dictionaries_ and list-of-lists would work. However, these lists of lists would need to be `object[][]`, because in general the dictionaries is `Dictionary<TKey, TValue>`.

So **it is unavoidable, IMO, to switch from lists-of-lists to lists-of-2-item-tuples** to retain full type safety.

> this has a slight implication on the syntax to write the filter.

The proposed approach expects _2-item tuples instead of lists_ in the input to the `In` method. Now this is the test code that works properly (note the tuples in the `In` call):

```
public class ZBook
{
    [ColumnPrimaryKey(1)]
    [ColumnName("title")]
    public string Title { get; set; } = null!;
    [ColumnName("metadata")]
    public Dictionary<string, string>? Metadata { get; set; }
}

[...]

    [Fact()]
    public async Task SteoFBuildersTableTypedInTest()
    {
        var filterBuilder = Builders<ZBook>.Filter;

        var filter = filterBuilder.In(
            b => b.Metadata,
            new[] {("language", "French"), ("edition", "Illustrated")}
        );

        var t = fixture.Database.GetTable<ZBook>("t");
        var row = await t.FindOneAsync(filter);
        Assert.NotNull(row);
        Assert.Equal(row.Title, "Le Loup");

    }
```

### Litmus test: heterogeneous keys/values

Now a table with a map whose key has different type than value:

```
-- CQL:
create table t2(title text primary key, metadata map<int,text>);
insert into t2(title,metadata) values ('Le Loup', {123:'French',456: 'Illustrated Edition'});
```

This is the untyped code to achieve the desired filtering:

```
    [Fact()]
    public async Task SteoFBuildersTableUntypedInTest2()
    {
        var filterBuilder = Builders<Row>.Filter;
        var filter = filterBuilder.In(
            "metadata",
            new[]
            {
                (123, "French" ),
                (456, "Illustrated Edition" ),
            }
        );

        var t = fixture.Database.GetTable("t2");
        var row = await t.FindOneAsync(filter);
        Assert.NotNull(row);
        Assert.Equal(((System.Text.Json.JsonElement)row["title"]).GetString(), "Le Loup");
    }
```

And this is the equivalent typed code:

```
public class ZBook2
{
    [ColumnPrimaryKey(1)]
    [ColumnName("title")]
    public string Title { get; set; } = null!;
    [ColumnName("metadata")]
    public Dictionary<int, string>? Metadata { get; set; }
}

[...]

    [Fact()]
    public async Task SteoFBuildersTableTypedInTest2()
    {
        var filterBuilder = Builders<ZBook2>.Filter;
        var filter = filterBuilder.In(
            b => b.Metadata,
            new[] {(123, "French"), (456, "Illustrated")}
        );

        var t = fixture.Database.GetTable<ZBook2>("t2");
        var row = await t.FindOneAsync(filter);
        Assert.NotNull(row);
        Assert.Equal(row.Title, "Le Loup");
    }
```