### PR TITLE
Naming alignments

### DIFF
--- a/.idea/.idea.DataStax.AstraDB.DataApi/.idea/workspace.xml
+++ b/.idea/.idea.DataStax.AstraDB.DataApi/.idea/workspace.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ChangeListManager">
+    <list default="true" id="599ec604-5a81-4903-aeb3-6b992ed05d2f" name="Changes" comment="">
+      <change beforePath="$PROJECT_DIR$/csharp-client.adoc" beforeDir="false" afterPath="$PROJECT_DIR$/csharp-client.adoc" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/index.md" beforeDir="false" afterPath="$PROJECT_DIR$/index.md" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/DataStax.AstraDB.DataApi/Admin/AstraDatabasesAdmin.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/DataStax.AstraDB.DataApi/Admin/AstraDatabasesAdmin.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/DataStax.AstraDB.DataApi/Admin/DatabaseAdminAstra.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/DataStax.AstraDB.DataApi/Admin/DatabaseAdminAstra.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/DataStax.AstraDB.DataApi/Admin/DatabaseAdminDataAPI.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/DataStax.AstraDB.DataApi/Admin/DatabaseAdminDataAPI.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/DataStax.AstraDB.DataApi/Collections/Collection.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/DataStax.AstraDB.DataApi/Collections/Collection.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/DataStax.AstraDB.DataApi/Core/CommandOptions.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/DataStax.AstraDB.DataApi/Core/CommandOptions.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/DataStax.AstraDB.DataApi/Core/Commands/Command.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/DataStax.AstraDB.DataApi/Core/Commands/Command.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/DataStax.AstraDB.DataApi/Core/CreateTableCommandOptions.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/DataStax.AstraDB.DataApi/Core/CreateTableCommandOptions.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/DataStax.AstraDB.DataApi/Core/CreateTypeCommandOptions.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/DataStax.AstraDB.DataApi/Core/CreateTypeCommandOptions.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/DataStax.AstraDB.DataApi/Core/DataAPIDestination.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/DataStax.AstraDB.DataApi/Core/DataAPIDestination.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/DataStax.AstraDB.DataApi/Core/Database.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/DataStax.AstraDB.DataApi/Core/Database.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/DataStax.AstraDB.DataApi/Core/DropTypeCommandOptions.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/DataStax.AstraDB.DataApi/Core/DropTypeCommandOptions.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/DataStax.AstraDB.DataApi/Core/InsertManyOptions.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/DataStax.AstraDB.DataApi/Core/InsertManyOptions.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/DataStax.AstraDB.DataApi/Core/ReplaceOptions.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/DataStax.AstraDB.DataApi/Core/ReplaceOptions.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/DataStax.AstraDB.DataApi/Core/TimeoutOptions.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/DataStax.AstraDB.DataApi/Core/TimeoutOptions.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/DataStax.AstraDB.DataApi/Core/UpdateOptions.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/DataStax.AstraDB.DataApi/Core/UpdateOptions.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/DataStax.AstraDB.DataApi/DataAPIClient.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/DataStax.AstraDB.DataApi/DataAPIClient.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/DataStax.AstraDB.DataApi/README.md" beforeDir="false" afterPath="$PROJECT_DIR$/src/DataStax.AstraDB.DataApi/README.md" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/DataStax.AstraDB.DataApi/Tables/CreateIndexCommandOptions.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/DataStax.AstraDB.DataApi/Tables/CreateIndexCommandOptions.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/DataStax.AstraDB.DataApi/Tables/DropIndexCommandOptions.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/DataStax.AstraDB.DataApi/Tables/DropIndexCommandOptions.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/DataStax.AstraDB.DataApi/Tables/DropUserDefinedTypeRequest.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/DataStax.AstraDB.DataApi/Tables/DropUserDefinedTypeRequest.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/DataStax.AstraDB.DataApi/Tables/Table.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/DataStax.AstraDB.DataApi/Tables/Table.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/DataStax.AstraDB.DataApi/Tables/UserDefinedTypeDefinition.cs" beforeDir="false" afterPath="$PROJECT_DIR$/src/DataStax.AstraDB.DataApi/Tables/UserDefinedTypeDefinition.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test/DataStax.AstraDB.DataApi.IntegrationTests/Fixtures/AdminFixture.cs" beforeDir="false" afterPath="$PROJECT_DIR$/test/DataStax.AstraDB.DataApi.IntegrationTests/Fixtures/AdminFixture.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test/DataStax.AstraDB.DataApi.IntegrationTests/Fixtures/AssemblyFixture.cs" beforeDir="false" afterPath="$PROJECT_DIR$/test/DataStax.AstraDB.DataApi.IntegrationTests/Fixtures/AssemblyFixture.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test/DataStax.AstraDB.DataApi.IntegrationTests/Fixtures/BaseFixture.cs" beforeDir="false" afterPath="$PROJECT_DIR$/test/DataStax.AstraDB.DataApi.IntegrationTests/Fixtures/BaseFixture.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdditionalTableTests.cs" beforeDir="false" afterPath="$PROJECT_DIR$/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdditionalTableTests.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/CollectionTests.cs" beforeDir="false" afterPath="$PROJECT_DIR$/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/CollectionTests.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/FindAndUpdateTests.cs" beforeDir="false" afterPath="$PROJECT_DIR$/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/FindAndUpdateTests.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/ReplaceAndDeleteTests.cs" beforeDir="false" afterPath="$PROJECT_DIR$/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/ReplaceAndDeleteTests.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/SearchTests.cs" beforeDir="false" afterPath="$PROJECT_DIR$/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/SearchTests.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/SerializationTests.cs" beforeDir="false" afterPath="$PROJECT_DIR$/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/SerializationTests.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/TableIndexesTests.cs" beforeDir="false" afterPath="$PROJECT_DIR$/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/TableIndexesTests.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/TableTests.cs" beforeDir="false" afterPath="$PROJECT_DIR$/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/TableTests.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/UpdateTests.cs" beforeDir="false" afterPath="$PROJECT_DIR$/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/UpdateTests.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test/DataStax.AstraDB.DataApi.UnitTests/GeneralTests.cs" beforeDir="false" afterPath="$PROJECT_DIR$/test/DataStax.AstraDB.DataApi.UnitTests/GeneralTests.cs" afterDir="false" />
+    </list>
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="CopilotPersistence">
+    <persistenceIdMap>
+      <entry key="_/Users/me/work/astra-db-csharp/astra-db-csharp" value="336rDmuUd4RoyD2Md47MR9HfzkP" />
+    </persistenceIdMap>
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="HighlightingSettingsPerFile">
+    <setting file="file://$APPLICATION_CONFIG_DIR$/resharper-host/DecompilerCache/decompiler/2c50feed06d34008a21934ead0382f3db400/3b/a97e5d37/Dictionary`2.cs" root0="FORCE_HIGHLIGHTING" />
+    <setting file="file://$APPLICATION_CONFIG_DIR$/resharper-host/DecompilerCache/decompiler/e31e5adc676d44c79a639a65fd4b8ed0cc600/17/5a0bd14c/Task.cs" root0="SKIP_HIGHLIGHTING" />
+    <setting file="file://$APPLICATION_CONFIG_DIR$/resharper-host/DecompilerCache/decompiler/e31e5adc676d44c79a639a65fd4b8ed0cc600/fb/142e485e/String.cs" root0="FORCE_HIGHLIGHTING" />
+    <setting file="file://$APPLICATION_CONFIG_DIR$/resharper-host/SourcesCache/308584f6cad3144a32d4212f8fa3b9cc81d089da95abcf3e5e5e8a7d7c873/JsonPropertyNameAttribute.cs" root0="FORCE_HIGHLIGHTING" />
+    <setting file="file://$APPLICATION_CONFIG_DIR$/resharper-host/SourcesCache/71f8a5297672ad56962c6af62f7241a092ad7d95eaee4ef564601be5d8e37b38/Int32.cs" root0="FORCE_HIGHLIGHTING" />
+    <setting file="file://$APPLICATION_CONFIG_DIR$/resharper-host/SourcesCache/c120c82e15a3dff119821a348ca241e694e92b886dd8c541547b37d603aff/JsonIgnoreAttribute.cs" root0="FORCE_HIGHLIGHTING" />
+    <setting file="file://$PROJECT_DIR$/docfx.json" root0="FORCE_HIGHLIGHTING" />
+    <setting file="file://$PROJECT_DIR$/src/DataStax.AstraDB.DataApi/obj/Debug/netstandard2.1/DataStax.AstraDB.DataApi.AssemblyInfo.cs" root0="SKIP_HIGHLIGHTING" />
+    <setting file="file://$PROJECT_DIR$/test/DataStax.AstraDB.DataApi.IntegrationTests/obj/DataStax.AstraDB.DataApi.IntegrationTests.csproj.nuget.dgspec.json" root0="FORCE_HIGHLIGHTING" />
+  </component>
+  <component name="ProblemsViewState">
+    <option name="selectedTabId" value="Toolset" />
+  </component>
+  <component name="ProjectColorInfo">{
+  &quot;associatedIndex&quot;: 0
+}</component>
+  <component name="ProjectId" id="336rDmuUd4RoyD2Md47MR9HfzkP" />
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "ModuleVcsDetector.initialDetectionPerformed": "true",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "RunOnceActivity.TerminalTabsStorage.copyFrom.TerminalArrangementManager.252": "true",
+    "RunOnceActivity.git.unshallow": "true",
+    "RunOnceActivity.typescript.service.memoryLimit.init": "true",
+    "git-widget-placeholder": "KG-renamings",
+    "nodejs_package_manager_path": "npm",
+    "settings.editor.selected.configurable": "preferences.keymap",
+    "vue.rearranger.settings.migration": "true"
+  }
+}]]></component>
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="599ec604-5a81-4903-aeb3-6b992ed05d2f" name="Changes" comment="" />
+      <created>1758648245639</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1758648245639</updated>
+      <workItem from="1758648247833" duration="174000" />
+      <workItem from="1771466564550" duration="2182000" />
+      <workItem from="1771890957796" duration="1858000" />
+      <workItem from="1771917621069" duration="24298000" />
+      <workItem from="1772504337100" duration="1050000" />
+      <workItem from="1772577495553" duration="18551000" />
+      <workItem from="1772817005296" duration="522000" />
+      <workItem from="1773159007357" duration="3819000" />
+      <workItem from="1773249181289" duration="970000" />
+      <workItem from="1773264196598" duration="1383000" />
+    </task>
+    <servers />
+  </component>
+  <component name="TypeScriptGeneratedFilesManager">
+    <option name="version" value="3" />
+  </component>
+  <component name="UnityProjectConfiguration" hasMinimizedUI="false" />
+  <component name="VcsManagerConfiguration">
+    <option name="CLEAR_INITIAL_COMMIT_MESSAGE" value="true" />
+  </component>
+  <component name="XDebuggerManager">
+    <breakpoint-manager>
+      <breakpoints>
+        <breakpoint enabled="true" type="DotNet_Exception_Breakpoints">
+          <properties exception="System.OperationCanceledException" breakIfHandledByOtherCode="false" displayValue="System.OperationCanceledException" />
+          <option name="timeStamp" value="1" />
+        </breakpoint>
+        <breakpoint enabled="true" type="DotNet_Exception_Breakpoints">
+          <properties exception="System.Threading.Tasks.TaskCanceledException" breakIfHandledByOtherCode="false" displayValue="System.Threading.Tasks.TaskCanceledException" />
+          <option name="timeStamp" value="2" />
+        </breakpoint>
+        <breakpoint enabled="true" type="DotNet_Exception_Breakpoints">
+          <properties exception="System.Threading.ThreadAbortException" breakIfHandledByOtherCode="false" displayValue="System.Threading.ThreadAbortException" />
+          <option name="timeStamp" value="3" />
+        </breakpoint>
+      </breakpoints>
+    </breakpoint-manager>
+  </component>
+  <component name="github-copilot-workspace">
+    <instructionFileLocations>
+      <option value=".github/instructions" />
+    </instructionFileLocations>
+    <promptFileLocations>
+      <option value=".github/prompts" />
+    </promptFileLocations>
+  </component>
+</project>

--- a/csharp-client.adoc
+++ b/csharp-client.adoc
@@ -11,14 +11,14 @@ The Data API stores structured data as `Documents` which are essentially key-val
 
 == Client hierarchy
 
-All interactions with the data begin with a DataApiClient object.
+All interactions with the data begin with a DataAPIClient object.
 
 Once you have an instance of a `DataAPIClient`, you can use it to get an instance of a `Database` object, which can be used to manage and access `Collection` objects which are themselves used to interact with the actual documents.
 
 [source,c#]
 ----
 //instantiate a client
-var client = new DataApiClient("YourTokenHere");
+var client = new DataAPIClient("YourTokenHere");
 
 //connect to a database
 var database = client.GetDatabase("YourDatabaseUrlHere");
@@ -41,7 +41,7 @@ The `CommandOptions` class provides a set of low-level options to control the in
 
 These options can be provided at any level of the SDK hierarchy:
 
-* `DataApiClient`
+* `DataAPIClient`
 ** `Database`
 *** `Collection`
 

--- a/index.md
+++ b/index.md
@@ -16,7 +16,7 @@ dotnet add package DataStax.AstraDB.DataApi --prerelease
 
 ```
 //instantiate a client
-var client = new DataApiClient("YourTokenHere");
+var client = new DataAPIClient("YourTokenHere");
 
 //connect to a database
 var database = client.GetDatabase("YourAPIEndpointHere");

--- a/src/DataStax.AstraDB.DataApi/Admin/AstraDatabasesAdmin.cs
+++ b/src/DataStax.AstraDB.DataApi/Admin/AstraDatabasesAdmin.cs
@@ -35,11 +35,11 @@ namespace DataStax.AstraDB.DataApi.Admin;
 public class AstraDatabasesAdmin
 {
     private readonly CommandOptions _adminOptions;
-    private readonly DataApiClient _client;
+    private readonly DataAPIClient _client;
 
     private CommandOptions[] OptionsTree => new CommandOptions[] { _client.ClientOptions, _adminOptions };
 
-    internal AstraDatabasesAdmin(DataApiClient client, CommandOptions adminOptions)
+    internal AstraDatabasesAdmin(DataAPIClient client, CommandOptions adminOptions)
     {
         Guard.NotNull(client, nameof(client));
         _client = client;

--- a/src/DataStax.AstraDB.DataApi/Admin/DatabaseAdminAstra.cs
+++ b/src/DataStax.AstraDB.DataApi/Admin/DatabaseAdminAstra.cs
@@ -40,10 +40,10 @@ namespace DataStax.AstraDB.DataApi.Admin
         private readonly Guid _id;
         private readonly Database _database;
         private readonly CommandOptions _adminOptions;
-        private readonly DataApiClient _client;
+        private readonly DataAPIClient _client;
         private CommandOptions[] _optionsTree => new CommandOptions[] { _client.ClientOptions, _adminOptions };
 
-        internal DatabaseAdminAstra(Database database, DataApiClient client, CommandOptions adminOptions)
+        internal DatabaseAdminAstra(Database database, DataAPIClient client, CommandOptions adminOptions)
         {
             Guard.NotNull(client, nameof(client));
             if (database.DatabaseId == null)

--- a/src/DataStax.AstraDB.DataApi/Admin/DatabaseAdminDataAPI.cs
+++ b/src/DataStax.AstraDB.DataApi/Admin/DatabaseAdminDataAPI.cs
@@ -40,10 +40,10 @@ namespace DataStax.AstraDB.DataApi.Admin
         private readonly Guid? _id;
         private readonly Database _database;
         private readonly CommandOptions _adminOptions;
-        private readonly DataApiClient _client;
+        private readonly DataAPIClient _client;
         private CommandOptions[] _optionsTree => new CommandOptions[] { _client.ClientOptions, _adminOptions };
 
-        internal DatabaseAdminDataAPI(Database database, DataApiClient client, CommandOptions adminOptions)
+        internal DatabaseAdminDataAPI(Database database, DataAPIClient client, CommandOptions adminOptions)
         {
             Guard.NotNull(client, nameof(client));
             _client = client;

--- a/src/DataStax.AstraDB.DataApi/Collections/Collection.cs
+++ b/src/DataStax.AstraDB.DataApi/Collections/Collection.cs
@@ -211,7 +211,7 @@ public class Collection<T, TId> : IQueryRunner<T, DocumentSortBuilder<T>> where 
         Guard.NotNullOrEmpty(documents, nameof(documents));
 
         if (insertOptions == null) insertOptions = new InsertManyOptions();
-        if (insertOptions.Concurrency > 1 && insertOptions.InsertInOrder)
+        if (insertOptions.Concurrency > 1 && insertOptions.IsOrdered)
         {
             throw new ArgumentException("Cannot run ordered insert_many concurrently.");
         }
@@ -240,7 +240,7 @@ public class Collection<T, TId> : IQueryRunner<T, DocumentSortBuilder<T>> where 
                         await semaphore.WaitAsync(bulkOperationTimeoutToken);
                         try
                         {
-                            var runResult = await RunInsertManyAsync(chunk, insertOptions.InsertInOrder, commandOptions, runSynchronously).ConfigureAwait(false);
+                            var runResult = await RunInsertManyAsync(chunk, insertOptions.IsOrdered, commandOptions, runSynchronously).ConfigureAwait(false);
                             lock (result.InsertedIds)
                             {
                                 result.InsertedIds.AddRange(runResult.InsertedIds);

--- a/src/DataStax.AstraDB.DataApi/Core/CommandOptions.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/CommandOptions.cs
@@ -27,7 +27,7 @@ namespace DataStax.AstraDB.DataApi.Core;
 /// This class provides a set of low-level options to control the interactions with the underlying data store.
 /// 
 /// These options can be provided at any level of the SDK hierarchy:
-///     <see cref="DataApiClient"/>
+///     <see cref="DataAPIClient"/>
 ///         <see cref="Database"/>
 ///             <see cref="Collections.Collection"/>
 ///             

--- a/src/DataStax.AstraDB.DataApi/Core/Commands/Command.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/Commands/Command.cs
@@ -34,7 +34,7 @@ internal class Command
 {
     private readonly ILogger _logger;
     private readonly List<CommandOptions> _commandOptionsTree;
-    private readonly DataApiClient _client;
+    private readonly DataAPIClient _client;
     private readonly CommandUrlBuilder _urlBuilder;
     private readonly string _name;
     private List<string> _urlPaths = new();
@@ -49,12 +49,12 @@ internal class Command
     private Func<HttpResponseMessage, Task> _responseHandler;
     internal Func<HttpResponseMessage, Task> ResponseHandler { set { _responseHandler = value; } }
 
-    internal Command(DataApiClient client, CommandOptions[] options, CommandUrlBuilder urlBuilder) : this(null, client, options, urlBuilder)
+    internal Command(DataAPIClient client, CommandOptions[] options, CommandUrlBuilder urlBuilder) : this(null, client, options, urlBuilder)
     {
 
     }
 
-    internal Command(string name, DataApiClient client, CommandOptions[] options, CommandUrlBuilder urlBuilder)
+    internal Command(string name, DataAPIClient client, CommandOptions[] options, CommandUrlBuilder urlBuilder)
     {
         _commandOptionsTree = options.ToList();
         _client = client;

--- a/src/DataStax.AstraDB.DataApi/Core/CreateTableCommandOptions.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/CreateTableCommandOptions.cs
@@ -24,5 +24,5 @@ public class CreateTableCommandOptions : DatabaseCommandOptions
   /// <summary>
   /// Skip creating the resource if it already exists (instead of throwing an error).
   /// </summary>
-  public bool SkipIfExists { get; set; } = false;
+  public bool IfNotExists { get; set; } = false;
 }

--- a/src/DataStax.AstraDB.DataApi/Core/CreateTypeCommandOptions.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/CreateTypeCommandOptions.cs
@@ -24,5 +24,5 @@ public class CreateTypeCommandOptions : CommandOptions
   /// <summary>
   /// Skip creating the type if one with the same name already exists
   /// </summary>
-  public bool SkipIfExists { get; set; } = false;
+  public bool IfNotExists { get; set; } = false;
 }

--- a/src/DataStax.AstraDB.DataApi/Core/DataAPIDestination.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/DataAPIDestination.cs
@@ -25,5 +25,5 @@ public enum DataApiDestination
     DSE,
     HCD,
     CASSANDRA,
-    OTHERS
+    OTHER
 }

--- a/src/DataStax.AstraDB.DataApi/Core/Database.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/Database.cs
@@ -37,13 +37,13 @@ namespace DataStax.AstraDB.DataApi.Core;
 /// </summary>
 /// <remarks>
 /// The Database class has a concept of a "current keyspace", which is the keyspace used for all operations. This can be overridden in each method call via an overload with the <see cref="DatabaseCommandOptions"/> parameter,
-/// or when creating the <see cref="Database"/> instance (see <see cref="DataApiClient.GetDatabase(string, DatabaseCommandOptions)"/>).
+/// or when creating the <see cref="Database"/> instance (see <see cref="DataAPIClient.GetDatabase(string, DatabaseCommandOptions)"/>).
 /// If unset, the default keyspace will be used.
 /// </remarks>
 /// <example>
 /// Using the default keyspace for all operations
 /// <code>
-/// var client = new DataApiClient("token");
+/// var client = new DataAPIClient("token");
 /// var database = client.GetDatabase("https://1ae8dd5d-19ce-452d-9df8-6e5b78b82ca7-us-east1.apps.astra.datastax.com");
 /// // Check to see if a collection exists in the default keyspace
 /// var doesCollectionExist = database.DoesCollectionExist("myCollection");
@@ -52,7 +52,7 @@ namespace DataStax.AstraDB.DataApi.Core;
 /// <example>
 /// Setting a custom keyspace for all operations
 /// <code>
-/// var client = new DataApiClient("token");
+/// var client = new DataAPIClient("token");
 /// var dbOptions = new DatabaseCommandOptions() { Keyspace = "myKeyspace" };
 /// var database = client.GetDatabase("https://1ae8dd5d-19ce-452d-9df8-6e5b78b82ca7-us-east1.apps.astra.datastax.com", dbOptions);
 /// // Check to see if a collection exists in the custom keyspace
@@ -62,7 +62,7 @@ namespace DataStax.AstraDB.DataApi.Core;
 /// <example>
 /// Setting a custom keyspace for a single operation
 /// <code>
-/// var client = new DataApiClient("token");
+/// var client = new DataAPIClient("token");
 /// var database = client.GetDatabase("https://1ae8dd5d-19ce-452d-9df8-6e5b78b82ca7-us-east1.apps.astra.datastax.com");
 /// // Check to see if a collection exists in the custom keyspace
 /// var dbOptions = new DatabaseCommandOptions() { Keyspace = "myKeyspace" };
@@ -74,14 +74,14 @@ public class Database
     internal const string DefaultKeyspace = "default_keyspace";
 
     private readonly string _apiEndpoint;
-    private readonly DataApiClient _client;
+    private readonly DataAPIClient _client;
     private readonly string _urlPostfix = "";
     private readonly Guid? _id;
 
     private DatabaseCommandOptions _dbCommandOptions;
 
     internal string ApiEndpoint => _apiEndpoint;
-    internal DataApiClient Client => _client;
+    internal DataAPIClient Client => _client;
     internal Guid? DatabaseId => _id;
 
     internal CommandOptions[] OptionsTree
@@ -92,7 +92,7 @@ public class Database
         }
     }
 
-    internal Database(string apiEndpoint, DataApiClient client, DatabaseCommandOptions dbCommandOptions)
+    internal Database(string apiEndpoint, DataAPIClient client, DatabaseCommandOptions dbCommandOptions)
     {
         Guard.NotNullOrEmpty(apiEndpoint, nameof(apiEndpoint));
         Guard.NotNull(client, nameof(client));
@@ -278,7 +278,7 @@ public class Database
 
     /// <summary>
     /// Create a new collection in the database, using the keyspace specified in the <see cref="DatabaseCommandOptions"/>
-    /// passed to the DataApiClient's GetDatabase method (for example: <see cref="DataApiClient.GetDatabase(string, DatabaseCommandOptions)"/>), or the default keyspace otherwise.
+    /// passed to the DataAPIClient's GetDatabase method (for example: <see cref="DataAPIClient.GetDatabase(string, DatabaseCommandOptions)"/>), or the default keyspace otherwise.
     /// </summary>
     /// <param name="collectionName">The name of the collection to create.</param>
     /// <returns>A reference to the created collection.</returns>
@@ -356,7 +356,7 @@ public class Database
 
     /// <summary>
     /// Create a new collection in the database, using the keyspace specified in the <see cref="DatabaseCommandOptions"/>
-    /// passed to the <see cref="DataApiClient.GetDatabase(string, DatabaseCommandOptions)"/> method, or the default keyspace otherwise.
+    /// passed to the <see cref="DataAPIClient.GetDatabase(string, DatabaseCommandOptions)"/> method, or the default keyspace otherwise.
     /// </summary>
     /// <typeparam name="T">The type to use for serialization/deserialization of the documents stored in the collection.</typeparam>
     /// <param name="collectionName">The name of the collection to create.</param>
@@ -626,7 +626,7 @@ public class Database
                 var typeName = UserDefinedTypeRequest.GetUserDefinedTypeName(udtProperty.UnderlyingType, udtProperty.Attribute);
                 if (!existingTypes.Contains(typeName))
                 {
-                    await CreateTypeAsync(typeName, UserDefinedTypeRequest.CreateDefinitionFromType(udtProperty.UnderlyingType), new CreateTypeCommandOptions() { SkipIfExists = true });
+                    await CreateTypeAsync(typeName, UserDefinedTypeRequest.CreateDefinitionFromType(udtProperty.UnderlyingType), new CreateTypeCommandOptions() { IfNotExists = true });
                 }
             }
         }
@@ -651,7 +651,7 @@ public class Database
     private async Task<Table<TRow>> CreateTableAsync<TRow>(string tableName, TableDefinition definition, CreateTableCommandOptions options, bool runSynchronously) where TRow : class
     {
         options = options ?? new CreateTableCommandOptions();
-        if (options.SkipIfExists)
+        if (options.IfNotExists)
         {
             var existingTables = await ListTableNamesAsync().ConfigureAwait(false);
             if (existingTables.Contains(tableName))
@@ -1093,7 +1093,7 @@ public class Database
             name = indexName,
             options = new
             {
-                ifExists = commandOptions?.SkipIfNotExists ?? false,
+                ifExists = commandOptions?.IfExists ?? false,
             }
         };
         var command = CreateCommand("dropIndex")
@@ -1228,7 +1228,7 @@ public class Database
             Name = typeName,
             TypeDefinition = definition
         };
-        request.SetSkipIfExists(options.SkipIfExists);
+        request.SetIfNotExists(options.IfNotExists);
         var command = CreateCommand("createType")
             .WithPayload(request)
             .WithTimeoutManager(new TableAdminTimeoutManager())
@@ -1329,7 +1329,7 @@ public class Database
         {
             Name = typeName
         };
-        request.SetSkipIfNotExists(options.SkipIfNotExists);
+        request.SetIfExists(options.IfExists);
         var command = CreateCommand("dropType")
             .WithPayload(request)
             .WithTimeoutManager(new TableAdminTimeoutManager())

--- a/src/DataStax.AstraDB.DataApi/Core/DropTypeCommandOptions.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/DropTypeCommandOptions.cs
@@ -24,5 +24,5 @@ public class DropTypeCommandOptions : CommandOptions
   /// <summary>
   /// Skip dropping the type if it does not exist (instead of throwing an error).
   /// </summary>
-  public bool SkipIfNotExists { get; set; } = false;
+  public bool IfExists { get; set; } = false;
 }

--- a/src/DataStax.AstraDB.DataApi/Core/InsertManyOptions.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/InsertManyOptions.cs
@@ -31,17 +31,17 @@ public class InsertManyOptions
     /// </summary>
     public const int MaxConcurrency = int.MaxValue;
 
-    private bool _insertInOrder = false;
+    private bool _isOrdered = false;
     /// <summary>
     /// Whether to insert documents in order or not.
     /// </summary>
-    public bool InsertInOrder
+    public bool IsOrdered
     {
-        get => _insertInOrder;
+        get => _isOrdered;
         set
         {
             if (value) Concurrency = 1;
-            _insertInOrder = value;
+            _isOrdered = value;
         }
     }
     /// <summary>

--- a/src/DataStax.AstraDB.DataApi/Core/ReplaceOptions.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/ReplaceOptions.cs
@@ -66,9 +66,9 @@ public class ReplaceOptions<T> where T : class
   /// Whether to insert the document if no matching document is found or not.
   /// </summary>
   [JsonIgnore]
-  public bool Upsert
+  public bool IsUpsert
   {
-    set => Parameters.Upsert = value;
+    set => Parameters.IsUpsert = value;
   }
 
   /// <summary>
@@ -86,7 +86,7 @@ internal class ReplaceOptionsParameters
   [JsonInclude]
   [JsonPropertyName("upsert")]
   [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-  internal bool? Upsert { get; set; }
+  internal bool? IsUpsert { get; set; }
 
   [JsonInclude]
   [JsonPropertyName("returnDocument")]

--- a/src/DataStax.AstraDB.DataApi/Core/TimeoutOptions.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/TimeoutOptions.cs
@@ -22,14 +22,14 @@ namespace DataStax.AstraDB.DataApi.Core;
 /// While timeouts can be set on a per-request basis (via the <see cref="CommandOptions.TimeoutOptions"/>), 
 /// when the timeouts are not specified, the default timeouts will be used. These can also be overridden
 /// by setting the <see cref="CommandOptions.TimeoutOptions.Defaults"/> property at any level in the command
-/// hierarchy (e.g. <see cref="DataApiClient"/>, <see cref="Database"/>, <see cref="Collections.Collection"/>).
+/// hierarchy (e.g. <see cref="DataAPIClient"/>, <see cref="Database"/>, <see cref="Collections.Collection"/>).
 /// </summary>
 /// <example>
 /// <code>
 /// The following example shows how to override the default timeouts at the client level.
 /// Let's change the defaults for each request, as well as those for collection administration operations,
 /// but leave the rest of the defaults unchanged.
-/// var client = new DataApiClient(new CommandOptions
+/// var client = new DataAPIClient(new CommandOptions
 /// {
 ///     TimeoutOptions = new TimeoutOptions
 ///     {

--- a/src/DataStax.AstraDB.DataApi/Core/UpdateOptions.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/UpdateOptions.cs
@@ -49,7 +49,7 @@ internal class UpdateOptionsParameters
   [JsonInclude]
   [JsonPropertyName("upsert")]
   [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-  internal bool? Upsert { get; set; }
+  internal bool? IsUpsert { get; set; }
 
   [JsonInclude]
   [JsonPropertyName("returnDocument")]
@@ -94,10 +94,10 @@ public class FindOneAndUpdateOptions<T> : UpdateOptions<T> where T : class
   /// Whether to insert a new document if the filter does not match any documents.
   /// </summary>
   [JsonIgnore]
-  public bool Upsert
+  public bool IsUpsert
   {
-    get => Parameters.Upsert ?? false;
-    set => Parameters.Upsert = value;
+    get => Parameters.IsUpsert ?? false;
+    set => Parameters.IsUpsert = value;
   }
 
   /// <summary>
@@ -131,10 +131,10 @@ public class UpdateOneOptions<T> : UpdateOptions<T> where T : class
   /// Whether to insert a new document if the filter does not match any documents.
   /// </summary>
   [JsonIgnore]
-  public bool Upsert
+  public bool IsUpsert
   {
-    get => Parameters.Upsert ?? false;
-    set => Parameters.Upsert = value;
+    get => Parameters.IsUpsert ?? false;
+    set => Parameters.IsUpsert = value;
   }
 }
 
@@ -148,10 +148,10 @@ public class UpdateManyOptions<T> : UpdateOptions<T> where T : class
   /// Whether to insert a new document if the filter does not match any documents.
   /// </summary>
   [JsonIgnore]
-  public bool Upsert
+  public bool IsUpsert
   {
-    get => Parameters.Upsert ?? false;
-    set => Parameters.Upsert = value;
+    get => Parameters.IsUpsert ?? false;
+    set => Parameters.IsUpsert = value;
   }
 
   [JsonIgnore]

--- a/src/DataStax.AstraDB.DataApi/DataAPIClient.cs
+++ b/src/DataStax.AstraDB.DataApi/DataAPIClient.cs
@@ -28,17 +28,17 @@ namespace DataStax.AstraDB.DataApi;
 /// The main entrypoint into working with the Data API. It sits at the top of the conceptual hierarchy of the SDK.
 /// The client can be passed a default token, which can be overridden by a stronger/weaker token when connectiong to a Database or Admin instance.
 /// 
-/// The DataApiClient, and the related methods for interacting with the database, accepts a set of options that can be used to affect the 
+/// The DataAPIClient, and the related methods for interacting with the database, accepts a set of options that can be used to affect the 
 /// command execution. These options can be specified at any level in the call hierarchy (Client, Database, Collection, Command, etc.) 
 /// The most specific defined option (or its default) will be used for each request.
 /// 
 ///
-///  Once you have a <see cref="DataApiClient"/> instance, 
+///  Once you have a <see cref="DataAPIClient"/> instance, 
 ///  you can use it to get a <see cref="Core.Database"/> instance.
 ///  From there you can create or connect to a <see cref="Collections.Collection"/>.
 ///  
 /// </summary>
-public class DataApiClient
+public class DataAPIClient
 {
     private readonly CommandOptions _options;
     private readonly ServiceProvider _serviceProvider;
@@ -51,48 +51,48 @@ public class DataApiClient
     internal ILogger Logger => _logger;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="DataApiClient"/> class.
+    /// Initializes a new instance of the <see cref="DataAPIClient"/> class.
     /// 
     /// When using this constructor, the token must be provided to the <see cref="GetDatabase"/> or 
     /// <see cref="GetAstraDatabasesAdmin"/> methods,
     /// or to the eventual end commands via a <see cref="CommandOptions"/> parameter.
     /// </summary>
-    public DataApiClient() : this(null, null)
+    public DataAPIClient() : this(null, null)
     {
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="DataApiClient"/> class with a default authentication token. 
+    /// Initializes a new instance of the <see cref="DataAPIClient"/> class with a default authentication token. 
     /// This token can be overridden when getting a database <see cref="GetDatabase"/> or admin instance <see cref="GetAstraDatabasesAdmin"/>
     /// as well as in the <see cref="CommandOptions"/> parameter of the commands.
     /// </summary>
     /// <param name="token">The token to use for authentication.</param>
-    public DataApiClient(string token)
+    public DataAPIClient(string token)
         : this(token, null)
     {
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="DataApiClient"/> class with a default set of options
+    /// Initializes a new instance of the <see cref="DataAPIClient"/> class with a default set of options
     /// When using this constructor, the token must be provided in the <see cref="CommandOptions"/> parameter,
     /// to the <see cref="GetDatabase"/> or <see cref="GetAstraDatabasesAdmin"/> methods,
     /// or the eventual end commands via a <see cref="CommandOptions"/> parameter.
     /// </summary>
     /// <param name="options">The default options to use for commands executed by this client.</param>
-    public DataApiClient(CommandOptions options)
+    public DataAPIClient(CommandOptions options)
         : this(null, options)
     {
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="DataApiClient"/> class with a default authentication token.
+    /// Initializes a new instance of the <see cref="DataAPIClient"/> class with a default authentication token.
     /// When using the default constructor, the token must be provided to the <see cref="GetDatabase"/> or <see cref="GetAstraDatabasesAdmin"/> methods
     /// or the eventual end commands via a <see cref="CommandOptions"/> parameter.
     /// </summary>
     /// <param name="token">The token to use for authentication.</param>
     /// <param name="options">The default options to use for commands executed by this client.</param>
     /// <param name="logger">The logger to use for logging.</param>
-    public DataApiClient(string token, CommandOptions options, ILogger logger = null)
+    public DataAPIClient(string token, CommandOptions options, ILogger logger = null)
     {
         _options = options ?? new CommandOptions();
         _options.Token = token;
@@ -107,7 +107,7 @@ public class DataApiClient
 
     /// <summary>
     /// Gets an instance of the <see cref="AstraDatabasesAdmin"/> class for administration of Astra databases.
-    /// Options (including token) from the <see cref="DataApiClient"/> will be passed to the <see cref="AstraDatabasesAdmin"/>
+    /// Options (including token) from the <see cref="DataAPIClient"/> will be passed to the <see cref="AstraDatabasesAdmin"/>
     /// and can be overridden by the <see cref="CommandOptions"/> parameter of the commands.
     /// </summary>
     /// <returns>An admin instance of the <see cref="AstraDatabasesAdmin"/> class.</returns>
@@ -118,9 +118,9 @@ public class DataApiClient
 
     /// <summary>
     /// Gets an instance of the <see cref="AstraDatabasesAdmin"/> class for administration of Astra databases.
-    /// Options from the <see cref="DataApiClient"/> will be passed to the <see cref="AstraDatabasesAdmin"/>
+    /// Options from the <see cref="DataAPIClient"/> will be passed to the <see cref="AstraDatabasesAdmin"/>
     /// and can be overridden by the <see cref="CommandOptions"/> parameter of the commands.
-    /// The <paramref name="superAdminToken"/> parameter is used to override the token from the <see cref="DataApiClient"/>
+    /// The <paramref name="superAdminToken"/> parameter is used to override the token from the <see cref="DataAPIClient"/>
     /// with a more specific token as needed for security purposes.
     /// </summary>
     /// <param name="superAdminToken">The super admin token to use for authentication.</param>
@@ -133,7 +133,7 @@ public class DataApiClient
     /// <summary>
     /// Gets an instance of the <see cref="AstraDatabasesAdmin"/> class.
     /// 
-    /// Any options provided in the <paramref name="adminOptions"/> parameter will take precedence over the options from the <see cref="DataApiClient"/>.
+    /// Any options provided in the <paramref name="adminOptions"/> parameter will take precedence over the options from the <see cref="DataAPIClient"/>.
     /// </summary>
     /// <param name="adminOptions">The options to use for the admin instance.</param>
     /// <returns>An admin instance of the <see cref="AstraDatabasesAdmin"/> class.</returns>
@@ -141,9 +141,9 @@ public class DataApiClient
     {
         var applicableOptions = CommandOptions.Merge(_options, adminOptions);
         var applicableDestination = applicableOptions.Destination;
-        Guard.Equals(applicableDestination, DataApiDestination.ASTRA, "Destinations other than ASTRA cannot be used with GetAstraAdmin. Please check your Destination settings for the DataApiClient or the overload with adminOptions");
+        Guard.Equals(applicableDestination, DataApiDestination.ASTRA, "Destinations other than ASTRA cannot be used with GetAstraAdmin. Please check your Destination settings for the DataAPIClient or the overload with adminOptions");
         var applicableToken = applicableOptions.Token;
-        Guard.NotNullOrEmpty(applicableToken, nameof(adminOptions.Token), "Token must be provided to the DataApiClient constructor or to a GetAstraAdmin() overload.");
+        Guard.NotNullOrEmpty(applicableToken, nameof(adminOptions.Token), "Token must be provided to the DataAPIClient constructor or to a GetAstraAdmin() overload.");
         return new AstraDatabasesAdmin(this, adminOptions);
     }
 
@@ -157,7 +157,7 @@ public class DataApiClient
     /// <returns>An instance of the <see cref="Database"/> class.</returns>
     /// <example>
     /// <code>
-    /// var client = new DataApiClient("token");
+    /// var client = new DataAPIClient("token");
     /// var database = client.GetDatabase("https://1ae8dd5d-19ce-452d-9df8-6e5b78b82ca7-us-east1.apps.astra.datastax.com");
     /// </code>
     /// </example>
@@ -176,7 +176,7 @@ public class DataApiClient
     /// <returns>An instance of the <see cref="Database"/> class.</returns>
     /// <example>
     /// <code>
-    /// var client = new DataApiClient("token");
+    /// var client = new DataAPIClient("token");
     /// var database = client.GetDatabase("https://1ae8dd5d-19ce-452d-9df8-6e5b78b82ca7-us-east1.apps.astra.datastax.com", "myKeyspace");
     /// </code>
     /// </example>
@@ -189,14 +189,14 @@ public class DataApiClient
     /// <summary>
     /// Gets an instance of a <see cref="Database"/> given the API Endpoint and a set of options.
     /// 
-    /// Any options provided in the <paramref name="dbOptions"/> parameter will take precedence over the options from the <see cref="DataApiClient"/>.
+    /// Any options provided in the <paramref name="dbOptions"/> parameter will take precedence over the options from the <see cref="DataAPIClient"/>.
     /// </summary>
     /// <param name="apiEndpoint">The API endpoint of the database.</param>
     /// <param name="dbOptions">The options to use for the database.</param>
     /// <returns>An instance of the <see cref="Database"/> class.</returns>
     /// <example>
     /// <code>
-    /// var client = new DataApiClient("token");
+    /// var client = new DataAPIClient("token");
     /// var database = client.GetDatabase("https://1ae8dd5d-19ce-452d-9df8-6e5b78b82ca7-us-east1.apps.astra.datastax.com", new DatabaseCommandOptions() { Keyspace = "myKeyspace" });
     /// </code>
     /// </example>

--- a/src/DataStax.AstraDB.DataApi/README.md
+++ b/src/DataStax.AstraDB.DataApi/README.md
@@ -39,7 +39,7 @@ Now do this:
 
 ```
 //instantiate a client
-var client = new DataApiClient();
+var client = new DataAPIClient();
 
 //connect to a database
 var database = client.GetDatabase("YourDatabaseUrlHere", "YourTokenHere");

--- a/src/DataStax.AstraDB.DataApi/Tables/CreateIndexCommandOptions.cs
+++ b/src/DataStax.AstraDB.DataApi/Tables/CreateIndexCommandOptions.cs
@@ -21,5 +21,5 @@ namespace DataStax.AstraDB.DataApi.Tables;
 
 public class CreateIndexCommandOptions : CommandOptions
 {
-  public bool SkipIfExists { get; set; } = false;
+  public bool IfNotExists { get; set; } = false;
 }

--- a/src/DataStax.AstraDB.DataApi/Tables/DropIndexCommandOptions.cs
+++ b/src/DataStax.AstraDB.DataApi/Tables/DropIndexCommandOptions.cs
@@ -21,5 +21,5 @@ namespace DataStax.AstraDB.DataApi.Tables;
 
 public class DropIndexCommandOptions : CommandOptions
 {
-  public bool SkipIfNotExists { get; set; } = false;
+  public bool IfExists { get; set; } = false;
 }

--- a/src/DataStax.AstraDB.DataApi/Tables/DropUserDefinedTypeRequest.cs
+++ b/src/DataStax.AstraDB.DataApi/Tables/DropUserDefinedTypeRequest.cs
@@ -12,10 +12,10 @@ internal class DropUserDefinedTypeRequest
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     internal Dictionary<string, object> Options { get; set; }
 
-    internal void SetSkipIfNotExists(bool skipIfNotExists)
+    internal void SetIfExists(bool ifExists)
     {
         var optionsKey = "ifExists";
-        if (!skipIfNotExists)
+        if (!ifExists)
         {
             if (Options != null)
             {
@@ -25,7 +25,7 @@ internal class DropUserDefinedTypeRequest
         else
         {
             Options ??= new Dictionary<string, object>();
-            Options[optionsKey] = skipIfNotExists;
+            Options[optionsKey] = ifExists;
         }
     }
 }

--- a/src/DataStax.AstraDB.DataApi/Tables/Table.cs
+++ b/src/DataStax.AstraDB.DataApi/Tables/Table.cs
@@ -48,31 +48,31 @@ public class Table<T> : IQueryRunner<T, TableSortBuilder<T>> where T : class
     }
 
     /// <summary>
-    /// Synchronous version of <see cref="ListIndexMetadataAsync()"/>
+    /// Synchronous version of <see cref="ListIndexesAsync()"/>
     /// </summary>
     /// <returns></returns>
-    public ListTableIndexMetadataResult ListIndexMetadata()
+    public ListTableIndexMetadataResult ListIndexes()
     {
-        return ListIndexMetadata(null);
+        return ListIndexes(null);
     }
 
     /// <summary>
-    /// Synchronous version of <see cref="ListIndexMetadataAsync(CommandOptions)"/>
+    /// Synchronous version of <see cref="ListIndexesAsync(CommandOptions)"/>
     /// </summary>
     /// <param name="commandOptions"></param>
     /// <returns></returns>
-    public ListTableIndexMetadataResult ListIndexMetadata(CommandOptions commandOptions)
+    public ListTableIndexMetadataResult ListIndexes(CommandOptions commandOptions)
     {
-        return ListIndexMetadataAsync(commandOptions, true).ResultSync();
+        return ListIndexesAsync(commandOptions, true).ResultSync();
     }
 
     /// <summary>
     /// Get a list of indexes for the table.
     /// </summary>
     /// <returns></returns>
-    public Task<ListTableIndexMetadataResult> ListIndexMetadataAsync()
+    public Task<ListTableIndexMetadataResult> ListIndexesAsync()
     {
-        return ListIndexMetadataAsync(null);
+        return ListIndexesAsync(null);
     }
 
     /// <summary>
@@ -80,12 +80,12 @@ public class Table<T> : IQueryRunner<T, TableSortBuilder<T>> where T : class
     /// </summary>
     /// <param name="commandOptions"></param>
     /// <returns></returns>
-    public Task<ListTableIndexMetadataResult> ListIndexMetadataAsync(CommandOptions commandOptions)
+    public Task<ListTableIndexMetadataResult> ListIndexesAsync(CommandOptions commandOptions)
     {
-        return ListIndexMetadataAsync(commandOptions, false);
+        return ListIndexesAsync(commandOptions, false);
     }
 
-    private async Task<ListTableIndexMetadataResult> ListIndexMetadataAsync(CommandOptions commandOptions, bool runSynchronously)
+    private async Task<ListTableIndexMetadataResult> ListIndexesAsync(CommandOptions commandOptions, bool runSynchronously)
     {
         var payload = new
         {
@@ -482,12 +482,12 @@ public class Table<T> : IQueryRunner<T, TableSortBuilder<T>> where T : class
         {
             indexName = $"{columnName}_idx";
         }
-        var indexResponse = await ListIndexMetadataAsync(commandOptions, runSynchronously);
+        var indexResponse = await ListIndexesAsync(commandOptions, runSynchronously);
         var exists = indexResponse?.Indexes?.Any(i => i.Name == indexName) == true;
 
         if (exists)
         {
-            if (commandOptions != null && commandOptions.SkipIfExists)
+            if (commandOptions != null && commandOptions.IfNotExists)
             {
                 return;
             }
@@ -582,7 +582,7 @@ public class Table<T> : IQueryRunner<T, TableSortBuilder<T>> where T : class
         Guard.NotNullOrEmpty(rows, nameof(rows));
 
         if (insertOptions == null) insertOptions = new InsertManyOptions();
-        if (insertOptions.Concurrency > 1 && insertOptions.InsertInOrder)
+        if (insertOptions.Concurrency > 1 && insertOptions.IsOrdered)
         {
             throw new ArgumentException("Cannot run ordered insert_many concurrently.");
         }
@@ -606,7 +606,7 @@ public class Table<T> : IQueryRunner<T, TableSortBuilder<T>> where T : class
                         await semaphore.WaitAsync(bulkOperationTimeoutToken);
                         try
                         {
-                            var runResult = await RunInsertManyAsync(chunk, insertOptions.InsertInOrder, insertOptions.ReturnDocumentResponses, commandOptions, runSynchronously).ConfigureAwait(false);
+                            var runResult = await RunInsertManyAsync(chunk, insertOptions.IsOrdered, insertOptions.ReturnDocumentResponses, commandOptions, runSynchronously).ConfigureAwait(false);
                             lock (result.InsertedIds)
                             {
                                 result.PrimaryKeys = runResult.PrimaryKeys;

--- a/src/DataStax.AstraDB.DataApi/Tables/UserDefinedTypeDefinition.cs
+++ b/src/DataStax.AstraDB.DataApi/Tables/UserDefinedTypeDefinition.cs
@@ -56,10 +56,10 @@ internal class UserDefinedTypeRequest
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     internal Dictionary<string, object> Options { get; set; }
 
-    internal void SetSkipIfExists(bool skipIfExists)
+    internal void SetIfNotExists(bool ifNotExists)
     {
         var optionsKey = "ifNotExists";
-        if (!skipIfExists)
+        if (!ifNotExists)
         {
             if (Options != null)
             {
@@ -69,7 +69,7 @@ internal class UserDefinedTypeRequest
         else
         {
             Options ??= new Dictionary<string, object>();
-            Options[optionsKey] = skipIfExists;
+            Options[optionsKey] = ifNotExists;
         }
     }
 

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Fixtures/AdminFixture.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Fixtures/AdminFixture.cs
@@ -33,7 +33,7 @@ public class AdminFixture : BaseFixture
 			return new DatabaseAdminAstra(database, Client, adminOptions);
 		}
 
-		return new DatabaseAdminOther(database, Client, adminOptions);
+		return new DatabaseAdminDataAPI(database, Client, adminOptions);
 	}
 
 	public static Guid? GetDatabaseIdFromUrl(string url)

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Fixtures/AssemblyFixture.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Fixtures/AssemblyFixture.cs
@@ -34,7 +34,7 @@ public class AssemblyFixture
 
     }
 
-    public DataApiClient CreateApiClient(string fixtureName, bool useToken = true)
+    public DataAPIClient CreateApiClient(string fixtureName, bool useToken = true)
     {
         using ILoggerFactory factory = LoggerFactory.Create(builder => builder.AddFileLogger($"../../../_logs/{fixtureName}_fixture_latest_run.log"));
         ILogger logger = factory.CreateLogger(fixtureName);
@@ -57,8 +57,8 @@ public class AssemblyFixture
             case "cassandra":
                 destination = DataApiDestination.CASSANDRA;
                 break;
-            case "others":
-                destination = DataApiDestination.OTHERS;
+            case "other":
+                destination = DataApiDestination.OTHER;
                 break;
             default:
                 destination = DataApiDestination.ASTRA;
@@ -73,7 +73,7 @@ public class AssemblyFixture
             Destination = destination,
         };
 
-        return new DataApiClient(useToken ? Token : null, clientOptions, logger);
+        return new DataAPIClient(useToken ? Token : null, clientOptions, logger);
     }
 
 }

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Fixtures/BaseFixture.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Fixtures/BaseFixture.cs
@@ -7,9 +7,9 @@ public class BaseFixture
 {
     private readonly AssemblyFixture _assemblyFixture;
 
-    public DataApiClient Client { get; set; }
+    public DataAPIClient Client { get; set; }
     public Database Database { get; set; }
-    public DataApiClient ClientWithoutToken { get; set; }
+    public DataAPIClient ClientWithoutToken { get; set; }
     public string DatabaseUrl { get; set; }
     public string Token { get; set; }
     public string Destination => _assemblyFixture.Destination;

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdditionalTableTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdditionalTableTests.cs
@@ -323,7 +323,7 @@ public class AdditionalTableTests
 
             var sameTable = await fixture.Database.CreateTableAsync<SimpleRowObject>(tableName, new CreateTableCommandOptions()
             {
-                SkipIfExists = true
+                IfNotExists = true
             });
             Assert.NotNull(sameTable);
         }

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/CollectionTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/CollectionTests.cs
@@ -582,7 +582,7 @@ public class CollectionTests
             };
 
             var collection = await fixture.Database.CreateCollectionAsync<DifferentIdsObject>(collectionName);
-            var result = await collection.InsertManyAsync(items, new InsertManyOptions() { InsertInOrder = true });
+            var result = await collection.InsertManyAsync(items, new InsertManyOptions() { IsOrdered = true });
 
             Assert.Equal(items.Count, result.InsertedIds.Count);
             for (var i = 0; i < result.InsertedIds.Count; i++)
@@ -613,7 +613,7 @@ public class CollectionTests
             }
             ;
             var collection = await fixture.Database.CreateCollectionAsync<SimpleObject, int>(collectionName);
-            var result = await collection.InsertManyAsync(items, new InsertManyOptions() { InsertInOrder = true });
+            var result = await collection.InsertManyAsync(items, new InsertManyOptions() { IsOrdered = true });
             await fixture.Database.DropCollectionAsync(collectionName);
             Assert.Equal(items.Count, result.InsertedIds.Count);
             for (var i = 0; i < 10; i++)
@@ -662,7 +662,7 @@ public class CollectionTests
             }
             ;
             var collection = await fixture.Database.CreateCollectionAsync<SimpleObject, int>(collectionName);
-            await collection.InsertManyAsync(items, new InsertManyOptions() { InsertInOrder = true });
+            await collection.InsertManyAsync(items, new InsertManyOptions() { IsOrdered = true });
             await Assert.ThrowsAsync<DocumentCountExceedsMaxException>(async () => await collection.CountDocumentsAsync(50));
 
         }

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/FindAndUpdateTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/FindAndUpdateTests.cs
@@ -95,7 +95,7 @@ public class FindAndUpdateTests
         var collection = fixture.UpdatesCollection;
         var filter = Builders<SimpleObject>.Filter.Eq(so => so._id, 111);
         var update = Builders<SimpleObject>.Update.SetOnInsert(so => so.Properties.PropertyTwo, "ThisWasSetOnInsert");
-        var result = await collection.FindOneAndUpdateAsync(filter, update, new FindOneAndUpdateOptions<SimpleObject> { Upsert = true, ReturnDocument = ReturnDocumentDirective.After });
+        var result = await collection.FindOneAndUpdateAsync(filter, update, new FindOneAndUpdateOptions<SimpleObject> { IsUpsert = true, ReturnDocument = ReturnDocumentDirective.After });
         Assert.Equal(111, result._id);
         Assert.Equal("ThisWasSetOnInsert", result.Properties.PropertyTwo);
     }

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/ReplaceAndDeleteTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/ReplaceAndDeleteTests.cs
@@ -78,7 +78,7 @@ public class ReplaceAndDeleteTests
     {
         var collection = fixture.ReplaceCollection;
         var filter = Builders<SimpleObject>.Filter.Eq(so => so._id, 111);
-        var options = new ReplaceOptions<SimpleObject>() { ReturnDocument = ReturnDocumentDirective.After, Upsert = true };
+        var options = new ReplaceOptions<SimpleObject>() { ReturnDocument = ReturnDocumentDirective.After, IsUpsert = true };
         var result = await collection.FindOneAndReplaceAsync(filter, CreateSimpleObject(), options);
         Assert.Equal("replacement", result.Properties.PropertyTwo);
     }

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/SearchTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/SearchTests.cs
@@ -78,7 +78,7 @@ public class SearchTests
             };
 
             var collection = await fixture.Database.CreateCollectionAsync<DifferentIdsObject>(collectionName);
-            await collection.InsertManyAsync(items, new InsertManyOptions() { InsertInOrder = true });
+            await collection.InsertManyAsync(items, new InsertManyOptions() { IsOrdered = true });
 
             //Search using Expression
             var filter = Builders<DifferentIdsObject>.Filter.Eq(d => d.TheId, 1);

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/SerializationTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/SerializationTests.cs
@@ -127,7 +127,7 @@ public class SerializationTests
 	{
 		string serializationTestString = "{\"primaryKeySchema\":{\"Name\":{\"type\":\"text\"}},\"insertedIds\":[[\"Test\"]]}";
 		var commandOptions = Array.Empty<CommandOptions>();
-		var command = new Command("deserializationTest", new DataApiClient(), commandOptions, null);
+		var command = new Command("deserializationTest", new DataAPIClient(), commandOptions, null);
 		var deserialized = command.Deserialize<TableInsertManyResult>(serializationTestString);
 		Assert.Equal("text", deserialized.PrimaryKeys["Name"].Type);
 		Assert.Equal("Test", deserialized.InsertedIds.First().First().ToString());
@@ -159,7 +159,7 @@ public class SerializationTests
 				OutputConverter = new DocumentConverter<HybridSearchTestObject>()
 			}
 		};
-		var command = new Command("deserializationTest", new DataApiClient(), commandOptions.ToArray(), null);
+		var command = new Command("deserializationTest", new DataAPIClient(), commandOptions.ToArray(), null);
 		var deserialized = command.Deserialize<ApiResponseWithData<ApiFindResult<HybridSearchTestObject>, FindStatusResult<RerankedResult<HybridSearchTestObject>>>>(serializationTestString);
 		Assert.NotNull(deserialized);
 		Assert.NotNull(deserialized.Data);

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/TableIndexesTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/TableIndexesTests.cs
@@ -35,13 +35,13 @@ public class TableIndexesTests
 
             Assert.Contains("already exists", ex.Message);
 
-            // second creation (should not fail when SkipIfExists is set)
+            // second creation (should not fail when IfNotExists is set)
             await table.CreateIndexAsync("category_idx_custom", (b) => b.Category, new CreateIndexCommandOptions()
             {
-                SkipIfExists = true
+                IfNotExists = true
             });
 
-            var result = await table.ListIndexMetadataAsync();
+            var result = await table.ListIndexesAsync();
             Assert.Contains(result.Indexes, i => i.Name == "category_idx_custom");
 
             //ensure insert still works
@@ -72,13 +72,13 @@ public class TableIndexesTests
 
             Assert.Contains("already exists", ex.Message);
 
-            // second creation (should not fail when SkipIfExists is set)
+            // second creation (should not fail when IfNotExists is set)
             await table.CreateIndexAsync("category_idx", (b) => b.Category, new CreateIndexCommandOptions()
             {
-                SkipIfExists = true
+                IfNotExists = true
             });
 
-            var result = await table.ListIndexMetadataAsync();
+            var result = await table.ListIndexesAsync();
             Assert.Contains(result.Indexes, i => i.Name == "category_idx");
 
             var insertResult = await TableIndexesFixture.AddTableRows(table);
@@ -100,7 +100,7 @@ public class TableIndexesTests
 
             await table.CreateIndexAsync("map_idx", (b) => b.StringMap, Builders.TableIndex.Map(MapIndexType.Entries));
 
-            var result = await table.ListIndexMetadataAsync();
+            var result = await table.ListIndexesAsync();
             Assert.Contains(result.Indexes, i => i.Name == "map_idx");
 
         }
@@ -120,7 +120,7 @@ public class TableIndexesTests
 
             await table.CreateIndexAsync("map_idx", (b) => b.StringMap, Builders.TableIndex.Map(MapIndexType.Keys));
 
-            var result = await table.ListIndexMetadataAsync();
+            var result = await table.ListIndexesAsync();
             Assert.Contains(result.Indexes, i => i.Name == "map_idx");
 
         }
@@ -140,7 +140,7 @@ public class TableIndexesTests
 
             await table.CreateIndexAsync("map_idx", (b) => b.StringMap, Builders.TableIndex.Map(MapIndexType.Values));
 
-            var result = await table.ListIndexMetadataAsync();
+            var result = await table.ListIndexesAsync();
             Assert.Contains(result.Indexes, i => i.Name == "map_idx");
 
         }
@@ -164,17 +164,17 @@ public class TableIndexesTests
 
             // drop should work
             await fixture.Database.DropTableIndexAsync(indexName);
-            var result = await table.ListIndexMetadataAsync();
+            var result = await table.ListIndexesAsync();
             Assert.DoesNotContain(result.Indexes, i => i.Name == indexName);
 
             // second drop (should fail)
             var ex = await Assert.ThrowsAsync<CommandException>(() =>
                 fixture.Database.DropTableIndexAsync(indexName));
 
-            // second drop (should not fail when SkipIfExists is set)
+            // second drop (should not fail when IfNotExists is set)
             await fixture.Database.DropTableIndexAsync(indexName, new DropIndexCommandOptions()
             {
-                SkipIfNotExists = true
+                IfExists = true
             });
         }
         finally
@@ -197,17 +197,17 @@ public class TableIndexesTests
 
             // drop should work
             await fixture.Database.DropTableIndexAsync(indexName);
-            var result = await table.ListIndexMetadataAsync();
+            var result = await table.ListIndexesAsync();
             Assert.DoesNotContain(result.Indexes, i => i.Name == indexName);
 
             // second drop (should fail)
             var ex = await Assert.ThrowsAsync<CommandException>(() =>
                 fixture.Database.DropTableIndexAsync(indexName));
 
-            // second drop (should not fail when SkipIfExists is set)
+            // second drop (should not fail when IfNotExists is set)
             await fixture.Database.DropTableIndexAsync(indexName, new DropIndexCommandOptions()
             {
-                SkipIfNotExists = true
+                IfExists = true
             });
         }
         finally

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/TableTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/TableTests.cs
@@ -119,7 +119,7 @@ public class TableTests
             var options = new InsertManyOptions
             {
                 ReturnDocumentResponses = true,
-                InsertInOrder = true,
+                IsOrdered = true,
                 ChunkSize = 2
             };
             var result = await table.InsertManyAsync(rows, options);

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/UpdateTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/UpdateTests.cs
@@ -171,7 +171,7 @@ public class UpdateTests
         var collection = fixture.UpdatesCollection;
         var filter = Builders<SimpleObject>.Filter.Eq(so => so._id, 111);
         var update = Builders<SimpleObject>.Update.SetOnInsert(so => so.Properties.PropertyTwo, "ThisWasSetOnInsert");
-        var result = await collection.UpdateOneAsync(filter, update, new UpdateOneOptions<SimpleObject> { Upsert = true });
+        var result = await collection.UpdateOneAsync(filter, update, new UpdateOneOptions<SimpleObject> { IsUpsert = true });
         Assert.Equal(0, result.ModifiedCount);
         Assert.NotNull(result.UpsertedId);
         Assert.Equal(0, result.MatchedCount);

--- a/test/DataStax.AstraDB.DataApi.UnitTests/GeneralTests.cs
+++ b/test/DataStax.AstraDB.DataApi.UnitTests/GeneralTests.cs
@@ -29,7 +29,7 @@ public class GeneralTests
     {
         string username = "cassandra";
         string password = "cassandra";
-        string result = DataApiClient.UsernamePasswordTokenProvider(username, password);
+        string result = DataAPIClient.UsernamePasswordTokenProvider(username, password);
         Assert.Equal("Cassandra:Y2Fzc2FuZHJh:Y2Fzc2FuZHJh", result);
     }
 }


### PR DESCRIPTION
Resolves #33 

Actual alignments done:
* `DatabaseAdminOther` -> `DatabaseAdminDataAPI`
* `InsertInOrder` -> `IsOrdered` + `Upsert` -> `IsUpsert`
  * Follows Mongo here
* `DataApiClient` -> `DataAPIClient`
* `SkipIfExists` -> `IfNotExists` + `SkipIfNotExists` -> `IfExists`
* `ListIndexMetadata` -> `ListIndexes`
* `DataApiDestination.OTHERS` -> `DataApiDestination.OTHER`

Omitted:
* `ColumnPrimaryKey[Sort]Attribute` -> `PrimaryKeyPartitionBy` / `PrimaryKeyPartitionSort`
  * It's probably fine as is... changing it would break the otherwise intact practice of prefixing and suffixing these attributes with `Column*` and `*Attribute`... and trying to adhere to these precedents while still changing the name would make them unnecessarily long
* `CollectionLexicalMatch` -> `LexicalMatch`
  * Not touching this for the time being since we'll be moving this into the dedicated `CollectionFilterBuilder`