### PR TITLE
Serialize nonempty dicts as lists-of-pairs for untyped table insertion

### DIFF
--- a/src/DataStax.AstraDB.DataApi/Core/Commands/Command.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/Commands/Command.cs
@@ -196,6 +196,11 @@ internal class Command
         if (commandOptions.InputConverter != null)
         {
             serializeOptions.Converters.Add(commandOptions.InputConverter);
+            // For untyped Row serialization, add TableDictionaryConverter to handle nested dictionaries
+            if (commandOptions.InputConverter is SimpleDictionaryConverter)
+            {
+                serializeOptions.Converters.Add(new TableDictionaryConverter());
+            }
         }
         if (log)
         {

--- a/src/DataStax.AstraDB.DataApi/SerDes/SimpleDictionaryConverter.cs
+++ b/src/DataStax.AstraDB.DataApi/SerDes/SimpleDictionaryConverter.cs
@@ -104,11 +104,19 @@ internal class SimpleDictionaryConverter
             if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Dictionary<,>))
             {
                 var keyType = type.GetGenericArguments()[0];
-                if (keyType != typeof(string))
+                var dict = (System.Collections.IDictionary)value;
+                
+                // Empty dictionaries remain as {}
+                if (dict.Count == 0)
                 {
+                    writer.WriteStartObject();
+                    writer.WriteEndObject();
+                }
+                else
+                {
+                    // Non-empty: [[k1,v1],[k2,v2],...]
                     var valueType = type.GetGenericArguments()[1];
                     writer.WriteStartArray();
-                    var dict = (System.Collections.IDictionary)value;
                     foreach (var key in dict.Keys)
                     {
                         writer.WriteStartArray();
@@ -117,8 +125,8 @@ internal class SimpleDictionaryConverter
                         writer.WriteEndArray();
                     }
                     writer.WriteEndArray();
-                    return;
                 }
+                return;
             }
         }
         JsonSerializer.Serialize(writer, value, options);

--- a/src/DataStax.AstraDB.DataApi/SerDes/TableDictionaryConverter.cs
+++ b/src/DataStax.AstraDB.DataApi/SerDes/TableDictionaryConverter.cs
@@ -1,0 +1,87 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace DataStax.AstraDB.DataApi.SerDes;
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// Converter factory for serializing dictionaries in table operations.
+/// Non-empty dictionaries are serialized as [[k1,v1],[k2,v2],...] format.
+/// Empty dictionaries are serialized as {}.
+/// </summary>
+internal class TableDictionaryConverter : JsonConverterFactory
+{
+    public override bool CanConvert(Type typeToConvert)
+    {
+        if (!typeToConvert.IsGenericType)
+            return false;
+            
+        return typeToConvert.GetGenericTypeDefinition() == typeof(Dictionary<,>);
+    }
+
+    public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+    {
+        Type keyType = typeToConvert.GetGenericArguments()[0];
+        Type valueType = typeToConvert.GetGenericArguments()[1];
+
+        JsonConverter converter = (JsonConverter)Activator.CreateInstance(
+            typeof(TableDictionaryConverterInner<,>).MakeGenericType(keyType, valueType),
+            BindingFlags.Instance | BindingFlags.Public,
+            binder: null,
+            args: null,
+            culture: null)!;
+
+        return converter;
+    }
+
+    private class TableDictionaryConverterInner<TKey, TValue> : JsonConverter<Dictionary<TKey, TValue>>
+    {
+        public override Dictionary<TKey, TValue> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            // For table operations, we primarily need write support
+            // Read support can be added if needed for deserialization
+            throw new NotImplementedException("TableDictionaryConverter is designed for serialization only");
+        }
+
+        public override void Write(Utf8JsonWriter writer, Dictionary<TKey, TValue> value, JsonSerializerOptions options)
+        {
+            if (value.Count == 0)
+            {
+                // Empty dictionaries remain as {}
+                writer.WriteStartObject();
+                writer.WriteEndObject();
+            }
+            else
+            {
+                // Non-empty dictionaries: [[k1,v1],[k2,v2],...]
+                writer.WriteStartArray();
+                foreach (var kvp in value)
+                {
+                    writer.WriteStartArray();
+                    JsonSerializer.Serialize(writer, kvp.Key, options);
+                    JsonSerializer.Serialize(writer, kvp.Value, options);
+                    writer.WriteEndArray();
+                }
+                writer.WriteEndArray();
+            }
+        }
+    }
+}

--- a/src/DataStax.AstraDB.DataApi/Tables/Table.cs
+++ b/src/DataStax.AstraDB.DataApi/Tables/Table.cs
@@ -1057,6 +1057,11 @@ public class Table<T> : IQueryRunner<T, TableSortBuilder<T>> where T : class
         commandOptions.SerializeDateAsDollarDate = false;
         if (typeof(TResult) == typeof(Row))
         {
+            // Register SimpleDictionaryConverter for untyped Row serialization
+            if (isInsert && typeof(T) == typeof(Row))
+            {
+                commandOptions.InputConverter = new SimpleDictionaryConverter();
+            }
             return commandOptions;
         }
         if (isInsert)


### PR DESCRIPTION
Fixes #96 .

As [remarked](https://ibm-analytics.slack.com/archives/C09J0DB1SJ1/p1771616019350919) by @skedwards88 , untyped table insertion seems not to serialize correctly (which raises API exceptions for non-string keys).
This PR aims at fixing this. To do so, a new converter is created, specific to the case, and injected when needed in the serialization stack. Note this is serialization only (no deserialization).

I _think_ this works as intended. The attached tests (which should be followed by manual payload inspection in the logs) ensure that:

- typed table insertions work correctly
- un/typed table insertions for empty dicts are `{}` as they should (as per #57 already)
- un/typed collection insertion are not affected (e.g. for nested dict-like documents)

Tests (ahem, paste them somewhere to run them):

```
public class SBook
{
  [ColumnPrimaryKey(1)]
  [ColumnName("title")]
  public string? Title { get; set; }

  [ColumnPrimaryKey(2)]
  [ColumnName("author")]
  public string? Author { get; set; }

  [ColumnName("map_column_int_str")]
  public Dictionary<int, string>? MapColumnIntStr { get; set; }

  [ColumnName("map_column_str_str")]
  public Dictionary<string, string>? MapColumnStrStr { get; set; }
}



[...]


    [Fact(Skip = "Unskip manually when needed.")]
    public async Task SteoNonstringMapTableInsertionTests()
    {

        var tableName = "steo_nonstrmap_insertiontest";

        try
        {
            var table = await fixture.Database.CreateTableAsync<SBook>(tableName,
                new CreateTableCommandOptions() { IfNotExists = true });
            var untypedTable = fixture.Database.GetTable(tableName);

            // typed insertion
            var row = new SBook()
            {
                MapColumnIntStr = new Dictionary<int, string>
                {
                    { 1, "value1" },
                    { 2, "value2" },
                },
                MapColumnStrStr = new Dictionary<string, string>
                {
                    { "key1", "value1" },
                    { "key2", "value2" },
                },
                Title = "Once in a Living Memory",
                Author = "Kayla McMaster",
            };
            await table.InsertOneAsync(row);
            var rowE = new SBook()
            {
                MapColumnIntStr = new Dictionary<int, string>{},
                MapColumnStrStr = new Dictionary<string, string>{},
                Title = "emptyT",
                Author = "emptyA",
            };
            await table.InsertOneAsync(rowE);

            // untyped insertion
            var untypedRow = new Row()
            {
                {
                    "map_column_int_str",
                    new Dictionary<int, string> { { 1, "value1" }, { 2, "value2" } }
                },
                {
                    "map_column_str_str",
                    new Dictionary<string, string>
                    {
                        { "key1", "value1" },
                        { "key2", "value2" },
                    }
                },
                { "title", "UNTY in a Living Memory" },
                { "author", "UNTYP McMaster" },
            };
            await untypedTable.InsertOneAsync(untypedRow);

            var untypedRowE = new Row()
            {
                {
                    "map_column_int_str",
                    new Dictionary<int, string> {}
                },
                {
                    "map_column_str_str",
                    new Dictionary<string, string> {}
                },
                { "title", "UNTYemptyT" },
                { "author", "UNTYemptyA" },
            };

            await untypedTable.InsertOneAsync(untypedRowE);
        }
        finally
        {
            await fixture.Database.DropTableAsync(tableName);
        }
    }

    [Fact(Skip = "Unskip manually when needed.")]
    public async Task SteoCollectionDictSerializationSanityTest()
    {
        var collName = "test_nestedobj_coll";
        try
        {
            var collection = await fixture.Database.CreateCollectionAsync<SteoNestedCollectionObject>(collName);
            var doc = new SteoNestedCollectionObject
            {
                _id = "one_typed",
                subobject = new SteoNestedCollectionSubobject { sfield = "sf0", ifield = 999 },
                subobject_map = new Dictionary<string, SteoNestedCollectionSubobject> {
                    ["key1"] = new SteoNestedCollectionSubobject { sfield = "sf11", ifield = 11 },
                    ["key2"] = new SteoNestedCollectionSubobject { sfield = "sf12", ifield = 12 }
                }
            };
            await collection.InsertOneAsync(doc);

            // untyped form
            var untypedCollection = fixture.Database.GetCollection(collName);
            var untypedDoc = new Document()
            {
                {"_id", "two_untyped"},
                {
                    "subobject",
                    new Dictionary<string, object>
                    {
                        {"sfield", "sf0"},
                        {"ifield", 999}
                    }
                },
                {
                    "subobject_map",
                    new Dictionary<string, object>
                    {
                        {
                            "key1",
                            new Dictionary<string, object>
                            {
                                {"sfield", "sf11"},
                                {"ifield", 11}
                            }
                        },
                        {
                            "key2",
                            new Dictionary<string, object>
                            {
                                {"sfield", "sf12"},
                                {"ifield", 12}
                            }
                        }
                    }
                }
            };
            await untypedCollection.InsertOneAsync(untypedDoc);
        }
        finally
        {
            await fixture.Database.DropCollectionAsync(collName);
        }
    }
```