### PR TITLE
support for 'set' on non-string table dictionary columns (un/typed)

### DIFF
--- a/src/DataStax.AstraDB.DataApi/Core/UpdateBuilder.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/UpdateBuilder.cs
@@ -222,19 +222,14 @@ public class UpdateBuilder<T>
     {
         if (value != null)
         {
-            var valueType = value.GetType();
-            var dictionaryInterface = valueType.GetInterfaces()
-                .FirstOrDefault(i => i.IsGenericType &&
-                                    i.GetGenericTypeDefinition() == typeof(IDictionary<,>));
-
-            if (dictionaryInterface != null && value is System.Collections.IDictionary dict)
+            if (value is System.Collections.IDictionary dict)
             {
-                var pairArrays = new List<object[]>();
-                foreach (var key in dict.Keys)
-                {
-                    pairArrays.Add(new object[] { key, dict[key] });
-                }
-                _updates.Add(new Update<T>(UpdateOperator.Set, fieldName, pairArrays.ToArray()));
+                var pairArrays = dict.Keys
+                    .Cast<object>()
+                    .Select(key => new object[] { key, dict[key]! })
+                    .ToArray();
+
+                _updates.Add(new Update<T>(UpdateOperator.Set, fieldName, pairArrays));
                 return this;
             }
         }

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdditionalTableTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdditionalTableTests.cs
@@ -354,14 +354,36 @@ public class AdditionalTableTests
                 .Set(r => r.DecimalKey, newDecimalKey)
                 .Set(r => r.StringDictionary, newStringKey);
             await table.UpdateOneAsync(filterBuilder.Eq(r => r.Id, 0), setterUpdate);
+            // read back and verify success
+            var readRowS = await table.FindOneAsync(filterBuilder.Eq(r => r.Id, 0));
+            Assert.Equal("the 201th", readRowS.IntKey[201]);
+            Assert.Equal("the decimal 301th", readRowS.DecimalKey[301.11m]);
+            Assert.Equal("LMN", readRowS.StringDictionary["PQR"]);
 
             // $set with non-string-keyed dictionaries, using tuples/dicts (untyped)
+            var newIntKeyTuplesU = new (int, string)[] {
+                (199, "the 199th U"),
+                (201, "the 201th U")
+            };
+            var newDecimalKeyU = new Dictionary<decimal, string>{
+                {299.99m, "the decimal 299th U"},
+                {301.11m, "the decimal 301th U"}
+            };
+            var newStringKeyU = new Dictionary<string, string>{
+                {"abc", "xyz U"},
+                {"PQR", "LMN U"}
+            };
             var setterUpdateUntyped = Builders<Row>
                 .Update
-                .Set("IntKey", newIntKeyTuples)
-                .Set("DecimalKey", newDecimalKey)
-                .Set("StringDictionary", newStringKey);
+                .Set("IntKey", newIntKeyTuplesU)
+                .Set("DecimalKey", newDecimalKeyU)
+                .Set("StringDictionary", newStringKeyU);
             await tableUntyped.UpdateOneAsync(filterBuilderUntyped.Eq("Id", 0), setterUpdateUntyped);
+            // read back and verify success
+            var readRowSu = await table.FindOneAsync(filterBuilder.Eq(r => r.Id, 0));
+            Assert.Equal("the 201th U", readRowSu.IntKey[201]);
+            Assert.Equal("the decimal 301th U", readRowSu.DecimalKey[301.11m]);
+            Assert.Equal("LMN U", readRowSu.StringDictionary["PQR"]);
 
             // Test empty maps with non-string keys (#57)
             var emptyMapRow = new DictionaryTypeTest()


### PR DESCRIPTION
Fixes #105 .

The approach allows to pass both dictionaries (made into lists-of-pairs no matter the key type, it does not hurt much) and lists of tuples (for analogy with the filter In/Nin case).

p.s. maybe there is a simpler form for the required type checks, but I landed on this one.