### PR TITLE
Mostly fix a failing `Test_EmptyColumnValues` test, but also add a new typed failing check in same test

### DIFF
--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/TestObjects.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/TestObjects.cs
@@ -411,6 +411,56 @@ public class TestDataBook
     public object? SummaryGenresVector { get; set; }
 }
 
+
+public class TestDataBookNonNullableCollections
+{
+    // This table uses a composite primary key
+    // with 'title' as the first column in the key
+    [ColumnPrimaryKey(1)]
+    [ColumnName("title")]
+    public string Title { get; set; } = null!;
+
+    // This table uses a composite primary key
+    // with 'author' as the second column in the key
+    [ColumnPrimaryKey(2)]
+    [ColumnName("author")]
+    public string Author { get; set; } = null!;
+
+    [ColumnName("number_of_pages")]
+    public int? NumberOfPages { get; set; }
+
+    [ColumnName("rating")]
+    public float? Rating { get; set; }
+
+    [ColumnName("publication_year")]
+    public int? PublicationYear { get; set; }
+
+    [ColumnName("summary")]
+    public string? Summary { get; set; }
+
+    [ColumnName("genres")]
+    public HashSet<string> Genres { get; set; }
+
+    [ColumnName("metadata")]
+    public Dictionary<string, string> Metadata { get; set; } = new Dictionary<string, string>();
+
+    [ColumnName("is_checked_out")]
+    public bool? IsCheckedOut { get; set; }
+
+    [ColumnName("borrower")]
+    public string? Borrower { get; set; }
+
+    [ColumnName("due_date")]
+    public DateTime? DueDate { get; set; }
+
+    // This column will store vector embeddings.
+    // The column will use an embedding model from NVIDIA to generate the
+    // vector embeddings when data is inserted to the column. 
+    [ColumnVectorize("nvidia", "NV-Embed-QA", dimension: 1024)]
+    [ColumnName("summary_genres_vector")]
+    public object? SummaryGenresVector { get; set; }
+}
+
 public class DateTypeTest
 {
     [ColumnPrimaryKey()]

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdditionalTableTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdditionalTableTests.cs
@@ -597,7 +597,6 @@ public class AdditionalTableTests
         }
     }
 
-    [SkipWhenNotAstra]
     [Fact]
     public async Task Test_EmptyColumnValues()
     {
@@ -629,6 +628,31 @@ public class AdditionalTableTests
             Assert.Null(findResult.Rating);
             Assert.Null(findResult.Genres);
 
+            var findManyResult = table.Find().ToList();
+            foreach (var item in findManyResult)
+            {
+                Assert.NotNull(item.Title);
+                Assert.Null(item.Rating);
+                Assert.Null(item.Genres);
+            }
+
+            // same reading, with a class whose 'Genres' is non-nullable (expect empty set)
+            var tableNonNullable = fixture.Database.GetTable<TestDataBookNonNullableCollections>(tableName);
+
+            var findResultNonNullable = await tableNonNullable.FindOneAsync();
+
+            // THESE CURRENTLY FAIL (both of course):
+            Assert.NotNull(findResultNonNullable.Genres);
+            Assert.Equal(0, findResultNonNullable.Genres.Count);
+
+            var findManyResultNonNullable = tableNonNullable.Find().ToList();
+            foreach (var itemNonNullable in findManyResultNonNullable)
+            {
+                // THESE CURRENTLY FAIL (both of course):
+                Assert.NotNull(itemNonNullable.Genres);
+                Assert.Equal(0, itemNonNullable.Genres.Count);
+            }
+
             //Test the non-typed version
             var tableNotTyped = fixture.Database.GetTable(tableName);
             var findUntyped = await tableNotTyped.FindOneAsync();
@@ -636,18 +660,20 @@ public class AdditionalTableTests
             Assert.Contains("rating", findUntyped);
             Assert.Null(findUntyped["rating"]);
             Assert.Contains("genres", findUntyped);
+
             Assert.NotNull(findUntyped["genres"]);
-            Assert.Empty(findUntyped["genres"] as List<object>);
+            Assert.Empty(findUntyped["genres"] as IEnumerable<object> ?? Enumerable.Empty<object>());
 
             var findManyUntypedResult = tableNotTyped.Find().ToList();
-            foreach (var item in findManyUntypedResult)
+            foreach (var untypedItem in findManyUntypedResult)
             {
-                Assert.NotNull(item["title"]);
-                Assert.Contains("rating", item);
-                Assert.Null(item["rating"]);
-                Assert.Contains("genres", item);
-                Assert.NotNull(item["genres"]);
-                Assert.Empty(item["genres"] as List<object>);
+                Assert.NotNull(untypedItem["title"]);
+                Assert.Contains("rating", untypedItem);
+                Assert.Null(untypedItem["rating"]);
+                Assert.Contains("genres", untypedItem);
+
+                Assert.NotNull(untypedItem["genres"]);
+                Assert.Empty(untypedItem["genres"] as IEnumerable<object> ?? Enumerable.Empty<object>());
             }
         }
         catch (Exception ex)


### PR DESCRIPTION
This PR serves as a suggestion to work around a regression silently introduced on main.
(silent because the test was disabled on HCD and did not get caught).

So, a (sound, pre-GA) solution is offered for the current failure, but _also a typed-read-path new problem is highlighted_, which I think should be addressed pre-GA. In more detail:

- enable `Test_EmptyColumnValues` test for HCD. The test behaves identically on Astra/HCD. (note for the future: are there any other tests that are Astra-only for no reason?)
- solve the untyped check on `Genres` (I think it comes from the fact that untyped now returns `JsonElement`s. A broader typecast resolved the failing check and I think it's ok from a untyped perspective)
- *PRE-GA IMPORTANT* Added a section of the test that currently fails. It should be addressed pre-ga. My expectation is that reading a table with a "nullempty" `set`, but using a typed approach with a _non-nullable HashSet_ for the field, should populate the row with an empty HashSet and not a null. Yet, the test shows one finds a Null there <--- would you agree this should be changed?
