### PR TITLE
#49 deserialize $vector -> $binary

### DIFF
--- a/src/DataStax.AstraDB.DataApi/Core/Commands/Command.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/Commands/Command.cs
@@ -179,7 +179,7 @@ internal class Command
         serializeOptions.Converters.Add(new ObjectIdConverter());
         serializeOptions.Converters.Add(new DurationConverter());
         serializeOptions.Converters.Add(new ByteArrayAsBinaryJsonConverter());
-        serializeOptions.Converters.Add(new FloatBinaryWriter());
+        serializeOptions.Converters.Add(new FloatArrayWriter());
         serializeOptions.Converters.Add(new TimeUuidJsonConverter());
 #if NET6_0_OR_GREATER
         serializeOptions.Converters.Add(new TimeOnlyConverter());

--- a/src/DataStax.AstraDB.DataApi/Core/Commands/Command.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/Commands/Command.cs
@@ -180,6 +180,7 @@ internal class Command
         serializeOptions.Converters.Add(new ObjectIdConverter());
         serializeOptions.Converters.Add(new DurationConverter());
         serializeOptions.Converters.Add(new ByteArrayAsBinaryJsonConverter());
+        serializeOptions.Converters.Add(new FloatBinaryWriter());
         serializeOptions.Converters.Add(new TimeUuidJsonConverter());
 #if NET6_0_OR_GREATER
         serializeOptions.Converters.Add(new TimeOnlyConverter());
@@ -232,6 +233,7 @@ internal class Command
         deserializeOptions.NumberHandling = JsonNumberHandling.AllowNamedFloatingPointLiterals;
         deserializeOptions.Converters.Add(new DurationConverter());
         deserializeOptions.Converters.Add(new ByteArrayAsBinaryJsonConverter());
+        deserializeOptions.Converters.Add(new FloatArrayJsonConverterBase());
         deserializeOptions.Converters.Add(new TimeUuidJsonConverter());
 #if NET6_0_OR_GREATER
         deserializeOptions.Converters.Add(new TimeOnlyConverter());

--- a/src/DataStax.AstraDB.DataApi/SerDes/BinaryConverter.cs
+++ b/src/DataStax.AstraDB.DataApi/SerDes/BinaryConverter.cs
@@ -27,29 +27,21 @@ namespace DataStax.AstraDB.DataApi.SerDes;
 /// </summary>
 public class ByteArrayAsBinaryJsonConverter : JsonConverter<byte[]>
 {
-    /// <summary>
-    /// Reads and converts a JSON <c>$binary</c> object to a <see cref="byte"/> array.
-    /// </summary>
+    /// <inheritdoc />
     public override byte[] Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
         if (reader.TokenType != JsonTokenType.StartObject)
-        {
             throw new JsonException($"Expected start of object when reading byte array, but got {reader.TokenType}.");
-        }
 
         string base64String = null;
 
         while (reader.Read())
         {
             if (reader.TokenType == JsonTokenType.EndObject)
-            {
                 break;
-            }
 
             if (reader.TokenType != JsonTokenType.PropertyName)
-            {
                 throw new JsonException($"Expected property name when reading byte array, but got {reader.TokenType}.");
-            }
 
             string propertyName = reader.GetString();
 
@@ -57,9 +49,7 @@ public class ByteArrayAsBinaryJsonConverter : JsonConverter<byte[]>
             {
                 reader.Read();
                 if (reader.TokenType != JsonTokenType.String)
-                {
                     throw new JsonException($"Expected string value for '{DataApiKeywords.Binary}', but got {reader.TokenType}.");
-                }
                 base64String = reader.GetString();
             }
             else
@@ -69,9 +59,7 @@ public class ByteArrayAsBinaryJsonConverter : JsonConverter<byte[]>
         }
 
         if (base64String == null)
-        {
             throw new JsonException($"Missing required property '{DataApiKeywords.Binary}'.");
-        }
 
         try
         {
@@ -83,13 +71,143 @@ public class ByteArrayAsBinaryJsonConverter : JsonConverter<byte[]>
         }
     }
 
-    /// <summary>
-    /// Writes a <see cref="byte"/> array as a JSON <c>$binary</c> object with a base-64 encoded value.
-    /// </summary>
+    /// <inheritdoc />
     public override void Write(Utf8JsonWriter writer, byte[] value, JsonSerializerOptions options)
     {
         writer.WriteStartObject();
         writer.WriteString(DataApiKeywords.Binary, Convert.ToBase64String(value));
+        writer.WriteEndObject();
+    }
+}
+
+/// <summary>
+/// JSON converter for float arrays. Serializes as a JSON array (<c>[1.0, 2.0]</c>)
+/// and deserializes from either a JSON array or the Data API binary format
+/// (<c>{ "$binary": "&lt;base64&gt;" }</c>). Use <see cref="FloatBinaryWriter"/> to serialize as binary instead.
+/// </summary>
+public class FloatArrayJsonConverterBase : JsonConverter<float[]>
+{
+    /// <inheritdoc />
+    public override float[] Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        return reader.TokenType switch
+        {
+            JsonTokenType.StartArray => ReadAsArray(ref reader),
+            JsonTokenType.StartObject => ReadAsBinary(ref reader),
+            _ => throw new JsonException($"Expected array or object when reading float array, but got {reader.TokenType}.")
+        };
+    }
+
+    private static float[] ReadAsArray(ref Utf8JsonReader reader)
+    {
+        var list = new System.Collections.Generic.List<float>();
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.EndArray)
+                break;
+            if (reader.TokenType != JsonTokenType.Number)
+                throw new JsonException($"Expected number in float array, but got {reader.TokenType}.");
+            list.Add(reader.GetSingle());
+        }
+        return list.ToArray();
+    }
+
+    private static float[] ReadAsBinary(ref Utf8JsonReader reader)
+    {
+        string base64String = null;
+
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.EndObject)
+                break;
+
+            if (reader.TokenType != JsonTokenType.PropertyName)
+                throw new JsonException($"Expected property name when reading float array, but got {reader.TokenType}.");
+
+            string propertyName = reader.GetString();
+
+            if (propertyName == DataApiKeywords.Binary)
+            {
+                reader.Read();
+                if (reader.TokenType != JsonTokenType.String)
+                    throw new JsonException($"Expected string value for '{DataApiKeywords.Binary}', but got {reader.TokenType}.");
+                base64String = reader.GetString();
+            }
+            else
+            {
+                reader.Skip();
+            }
+        }
+
+        if (base64String == null)
+            throw new JsonException($"Missing required property '{DataApiKeywords.Binary}'.");
+
+        byte[] bytes;
+        try
+        {
+            bytes = Convert.FromBase64String(base64String);
+        }
+        catch (FormatException ex)
+        {
+            throw new JsonException($"Invalid Base64 string: '{base64String}'.", ex);
+        }
+
+        if (bytes.Length % 4 != 0)
+            throw new JsonException($"Binary data length {bytes.Length} is not a multiple of 4 (required for float array).");
+
+        var floats = new float[bytes.Length / 4];
+        for (int i = 0; i < floats.Length; i++)
+        {
+            int offset = i * 4;
+            if (BitConverter.IsLittleEndian)
+            {
+                var chunk = new byte[] { bytes[offset + 3], bytes[offset + 2], bytes[offset + 1], bytes[offset] };
+                floats[i] = BitConverter.ToSingle(chunk, 0);
+            }
+            else
+            {
+                floats[i] = BitConverter.ToSingle(bytes, offset);
+            }
+        }
+        return floats;
+    }
+
+    /// <inheritdoc />
+    public override void Write(Utf8JsonWriter writer, float[] value, JsonSerializerOptions options)
+    {
+        writer.WriteStartArray();
+        foreach (var f in value)
+            writer.WriteNumberValue(f);
+        writer.WriteEndArray();
+    }
+}
+
+/// <summary>
+/// Serializes a float array to a JSON array: <c>[1.0, 2.0, 3.0]</c>.
+/// Deserializes from either JSON array or binary format.
+/// </summary>
+public class FloatArrayWriter : FloatArrayJsonConverterBase { }
+
+/// <summary>
+/// Serializes a float array to the Data API binary format:
+/// <c>{ "$binary": "&lt;base64&gt;" }</c> with big-endian IEEE 754 encoding.
+/// Deserializes from either binary or JSON array format.
+/// </summary>
+public class FloatBinaryWriter : FloatArrayJsonConverterBase
+{
+    /// <inheritdoc />
+    public override void Write(Utf8JsonWriter writer, float[] value, JsonSerializerOptions options)
+    {
+        var bytes = new byte[value.Length * 4];
+        for (int i = 0; i < value.Length; i++)
+        {
+            var chunk = BitConverter.GetBytes(value[i]);
+            if (BitConverter.IsLittleEndian)
+                Array.Reverse(chunk);
+            Buffer.BlockCopy(chunk, 0, bytes, i * 4, 4);
+        }
+        writer.WriteStartObject();
+        writer.WriteString(DataApiKeywords.Binary, Convert.ToBase64String(bytes));
         writer.WriteEndObject();
     }
 }

--- a/src/DataStax.AstraDB.DataApi/SerDes/BinaryConverter.cs
+++ b/src/DataStax.AstraDB.DataApi/SerDes/BinaryConverter.cs
@@ -105,9 +105,25 @@ public class FloatArrayJsonConverterBase : JsonConverter<float[]>
         {
             if (reader.TokenType == JsonTokenType.EndArray)
                 break;
-            if (reader.TokenType != JsonTokenType.Number)
+            if (reader.TokenType == JsonTokenType.Number)
+            {
+                list.Add(reader.GetSingle());
+            }
+            else if (reader.TokenType == JsonTokenType.String)
+            {
+                // AllowNamedFloatingPointLiterals encodes NaN/Infinity/-Infinity as strings
+                list.Add(reader.GetString() switch
+                {
+                    "NaN" => float.NaN,
+                    "Infinity" => float.PositiveInfinity,
+                    "-Infinity" => float.NegativeInfinity,
+                    var s => throw new JsonException($"Unexpected string value '{s}' in float array.")
+                });
+            }
+            else
+            {
                 throw new JsonException($"Expected number in float array, but got {reader.TokenType}.");
-            list.Add(reader.GetSingle());
+            }
         }
         return list.ToArray();
     }
@@ -177,7 +193,16 @@ public class FloatArrayJsonConverterBase : JsonConverter<float[]>
     {
         writer.WriteStartArray();
         foreach (var f in value)
-            writer.WriteNumberValue(f);
+        {
+            if (float.IsNaN(f))
+                writer.WriteStringValue("NaN");
+            else if (float.IsPositiveInfinity(f))
+                writer.WriteStringValue("Infinity");
+            else if (float.IsNegativeInfinity(f))
+                writer.WriteStringValue("-Infinity");
+            else
+                writer.WriteNumberValue(f);
+        }
         writer.WriteEndArray();
     }
 }

--- a/src/DataStax.AstraDB.DataApi/SerDes/DocumentConverter.cs
+++ b/src/DataStax.AstraDB.DataApi/SerDes/DocumentConverter.cs
@@ -163,7 +163,16 @@ public class DocumentConverter<T> : JsonConverter<T>
 
                 writer.WritePropertyName(propertyName);
 
-                JsonSerializer.Serialize(writer, propValue, prop.PropertyType, options);
+                if (docMappingAttr?.Field == DocumentMappingField.Vector
+                    && prop.PropertyType == typeof(float[])
+                    && propValue is float[] floatVec)
+                {
+                    new FloatBinaryWriter().Write(writer, floatVec, options);
+                }
+                else
+                {
+                    JsonSerializer.Serialize(writer, propValue, prop.PropertyType, options);
+                }
             }
         }
 

--- a/src/DataStax.AstraDB.DataApi/SerDes/RowConverter.cs
+++ b/src/DataStax.AstraDB.DataApi/SerDes/RowConverter.cs
@@ -206,6 +206,12 @@ public class RowConverter<T> : JsonConverter<T> where T : class
                         }
                     }
                 }
+                else if (property.GetCustomAttribute<ColumnVectorAttribute>() != null
+                    && type == typeof(float[])
+                    && propertyValue is float[] floatVec)
+                {
+                    new FloatBinaryWriter().Write(writer, floatVec, options);
+                }
                 else
                 {
                     JsonSerializer.Serialize(writer, propertyValue, type, options);

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/TestObjects.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/TestObjects.cs
@@ -544,6 +544,13 @@ public class BinaryVectorObject
     public float[] TheVector { get; set; }
 }
 
+public class PlainFloatArrayObject
+{
+    [DocumentId]
+    public string _id { get; set; }
+    public float[] Values { get; set; }
+}
+
 public class FloatArrayWriterObject
 {
     [DocumentId]

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/TestObjects.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/TestObjects.cs
@@ -510,7 +510,8 @@ public class SBook
     public Dictionary<string, string> MapColumnStrStr { get; set; }
 }
 
-public class FloatingPointTest{
+public class FloatingPointTest
+{
     [ColumnPrimaryKey]
     public string id { get; set; }
     public float p_float_nan { get; set; }
@@ -528,8 +529,33 @@ public class FloatingPointTest{
 public class CollectionDatetimeObject
 {
     [DocumentId]
-    public string _id {get; set;}
+    public string _id { get; set; }
     public DateTime dt_naive { get; set; }
     public DateTime dt_aware { get; set; }
     public DateTime dt_unspecified { get; set; }
+}
+
+public class BinaryVectorObject
+{
+    [DocumentId]
+    public string _id { get; set; }
+    [DocumentMapping(DocumentMappingField.Vector)]
+    [ColumnVector(3)]
+    public float[] TheVector { get; set; }
+}
+
+public class FloatArrayWriterObject
+{
+    [DocumentId]
+    public string _id { get; set; }
+    [JsonConverter(typeof(FloatArrayWriter))]
+    public float[] Vector { get; set; }
+}
+
+public class FloatBinaryWriterObject
+{
+    [DocumentId]
+    public string _id { get; set; }
+    [JsonConverter(typeof(FloatBinaryWriter))]
+    public float[] Vector { get; set; }
 }

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/SerializationTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/SerializationTests.cs
@@ -248,6 +248,38 @@ public class SerializationTests
 	private const string _knownBinaryBase64 = "PczMzb5MzM0+mZma";
 
 	[Fact]
+	public void Test_PlainFloatArray_Serialization_ProducesJsonArray()
+	{
+		var obj = new PlainFloatArrayObject { _id = "test-pfa-1", Values = new[] { 1.0f, 2.0f, 3.0f } };
+		var collection = fixture.Database.GetCollection<PlainFloatArrayObject>("serializationTest3");
+		string serialized = collection.CheckSerialization(obj);
+		Assert.Contains("\"Values\": [", serialized);
+		Assert.DoesNotContain("$binary", serialized);
+	}
+
+	[Fact]
+	public void Test_DocumentMappingVector_Serialization_ProducesBinaryInsideDollarVector()
+	{
+		var obj = new BinaryVectorObject { _id = "test-dmv-1", TheVector = new[] { 0.1f, -0.2f, 0.3f } };
+		var collection = fixture.Database.GetCollection<BinaryVectorObject>("serializationTest3");
+		var commandOptions = new CommandOptions() { InputConverter = new DocumentConverter<BinaryVectorObject>() };
+		string serialized = collection.CheckSerialization(obj, commandOptions);
+		Assert.Contains("\"$vector\":", serialized);
+		Assert.Contains("\"$binary\":", serialized);
+	}
+
+	[Fact]
+	public void Test_RowConverter_ColumnVector_Serialization_ProducesBinary()
+	{
+		var row = new RowTestObject { Name = "test-row-1", Vector = new[] { 0.1f, 0.2f, 0.3f, 0.4f } };
+		var commandOptions = new[] { new CommandOptions() { InputConverter = new RowConverter<RowTestObject>() } };
+		var command = new Command("serializationTest", new DataAPIClient(), commandOptions, null);
+		string serialized = command.Serialize(row);
+		Assert.Contains("\"$binary\":", serialized);
+		Assert.DoesNotContain("\"Vector\": [", serialized);
+	}
+
+	[Fact]
 	public void Test_FloatArrayWriter_Serialization_ProducesJsonArray()
 	{
 		var obj = new FloatArrayWriterObject { _id = "test-fa-1", Vector = new[] { 1.0f, 2.0f, 3.0f } };

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/SerializationTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/SerializationTests.cs
@@ -229,6 +229,126 @@ public class SerializationTests
 		Assert.Equal(TimeOnly.Parse("22:30:03.2696015"), deserialized.Time);
 	}
 
+	[Fact]
+	public void Test_BinaryVector()
+	{
+		var serializationTestString = @"
+			{""_id"":""1f7478e1-fc54-4d76-b478-e1fc54dd767d"",""$vector"":{""$binary"":""PczMzb5MzM0+mZma""}}
+		";
+		var collection = fixture.Database.GetCollection<BinaryVectorObject>("serializationTest3");
+		var commandOptions = new CommandOptions()
+		{
+			OutputConverter = new DocumentConverter<BinaryVectorObject>()
+		};
+		var deserialized = collection.CheckDeserialization(serializationTestString, commandOptions);
+		Assert.NotNull(deserialized.TheVector);
+	}
+
+	private static readonly float[] _knownBinaryFloats = new[] { 0.1f, -0.2f, 0.3f };
+	private const string _knownBinaryBase64 = "PczMzb5MzM0+mZma";
+
+	[Fact]
+	public void Test_FloatArrayWriter_Serialization_ProducesJsonArray()
+	{
+		var obj = new FloatArrayWriterObject { _id = "test-fa-1", Vector = new[] { 1.0f, 2.0f, 3.0f } };
+		var collection = fixture.Database.GetCollection<FloatArrayWriterObject>("serializationTest3");
+		var commandOptions = new CommandOptions() { OutputConverter = new DocumentConverter<FloatArrayWriterObject>() };
+		string serialized = collection.CheckSerialization(obj, commandOptions);
+		Assert.Contains("\"Vector\": [", serialized);
+		Assert.DoesNotContain("$binary", serialized);
+	}
+
+	[Fact]
+	public void Test_FloatBinaryWriter_Serialization_ProducesBinaryFormat()
+	{
+		var obj = new FloatBinaryWriterObject { _id = "test-fb-1", Vector = new[] { 1.0f, 2.0f, 3.0f } };
+		var collection = fixture.Database.GetCollection<FloatBinaryWriterObject>("serializationTest3");
+		var commandOptions = new CommandOptions() { OutputConverter = new DocumentConverter<FloatBinaryWriterObject>() };
+		string serialized = collection.CheckSerialization(obj, commandOptions);
+		Assert.Contains("\"$binary\":", serialized);
+		Assert.DoesNotContain("[", serialized[serialized.IndexOf("Vector")..]);
+	}
+
+	[Fact]
+	public void Test_FloatArrayWriter_Deserialization_FromJsonArray()
+	{
+		var json = @"{""_id"":""test-fa-2"",""Vector"":[0.1,0.2,0.3]}";
+		var collection = fixture.Database.GetCollection<FloatArrayWriterObject>("serializationTest3");
+		var commandOptions = new CommandOptions() { OutputConverter = new DocumentConverter<FloatArrayWriterObject>() };
+		var deserialized = collection.CheckDeserialization(json, commandOptions);
+		Assert.NotNull(deserialized.Vector);
+		Assert.Equal(3, deserialized.Vector.Length);
+		Assert.Equal(0.1f, deserialized.Vector[0]);
+		Assert.Equal(0.2f, deserialized.Vector[1]);
+		Assert.Equal(0.3f, deserialized.Vector[2]);
+	}
+
+	[Fact]
+	public void Test_FloatArrayWriter_Deserialization_FromBinaryFormat()
+	{
+		var json = $@"{{""_id"":""test-fa-3"",""Vector"":{{""$binary"":""{_knownBinaryBase64}""}}}}";
+		var collection = fixture.Database.GetCollection<FloatArrayWriterObject>("serializationTest3");
+		var commandOptions = new CommandOptions() { OutputConverter = new DocumentConverter<FloatArrayWriterObject>() };
+		var deserialized = collection.CheckDeserialization(json, commandOptions);
+		Assert.NotNull(deserialized.Vector);
+		Assert.Equal(_knownBinaryFloats.Length, deserialized.Vector.Length);
+		Assert.Equal(_knownBinaryFloats[0], deserialized.Vector[0]);
+		Assert.Equal(_knownBinaryFloats[1], deserialized.Vector[1]);
+		Assert.Equal(_knownBinaryFloats[2], deserialized.Vector[2]);
+	}
+
+	[Fact]
+	public void Test_FloatBinaryWriter_Deserialization_FromBinaryFormat()
+	{
+		var json = $@"{{""_id"":""test-fb-2"",""Vector"":{{""$binary"":""{_knownBinaryBase64}""}}}}";
+		var collection = fixture.Database.GetCollection<FloatBinaryWriterObject>("serializationTest3");
+		var commandOptions = new CommandOptions() { OutputConverter = new DocumentConverter<FloatBinaryWriterObject>() };
+		var deserialized = collection.CheckDeserialization(json, commandOptions);
+		Assert.NotNull(deserialized.Vector);
+		Assert.Equal(_knownBinaryFloats.Length, deserialized.Vector.Length);
+		Assert.Equal(_knownBinaryFloats[0], deserialized.Vector[0]);
+		Assert.Equal(_knownBinaryFloats[1], deserialized.Vector[1]);
+		Assert.Equal(_knownBinaryFloats[2], deserialized.Vector[2]);
+	}
+
+	[Fact]
+	public void Test_FloatBinaryWriter_Deserialization_FromJsonArray()
+	{
+		var json = @"{""_id"":""test-fb-3"",""Vector"":[0.1,0.2,0.3]}";
+		var collection = fixture.Database.GetCollection<FloatBinaryWriterObject>("serializationTest3");
+		var commandOptions = new CommandOptions() { OutputConverter = new DocumentConverter<FloatBinaryWriterObject>() };
+		var deserialized = collection.CheckDeserialization(json, commandOptions);
+		Assert.NotNull(deserialized.Vector);
+		Assert.Equal(3, deserialized.Vector.Length);
+		Assert.Equal(0.1f, deserialized.Vector[0]);
+		Assert.Equal(0.2f, deserialized.Vector[1]);
+		Assert.Equal(0.3f, deserialized.Vector[2]);
+	}
+
+	[Fact]
+	public void Test_FloatArrayWriter_Roundtrip()
+	{
+		var original = new FloatArrayWriterObject { _id = "test-fa-rt", Vector = new[] { 1.5f, -2.5f, 3.5f } };
+		var collection = fixture.Database.GetCollection<FloatArrayWriterObject>("serializationTest3");
+		var commandOptions = new CommandOptions() { OutputConverter = new DocumentConverter<FloatArrayWriterObject>() };
+		string serialized = collection.CheckSerialization(original, commandOptions);
+		var deserialized = collection.CheckDeserialization(serialized, commandOptions);
+		Assert.NotNull(deserialized.Vector);
+		Assert.Equal(original.Vector, deserialized.Vector);
+	}
+
+	[Fact]
+	public void Test_FloatBinaryWriter_Roundtrip()
+	{
+		var original = new FloatBinaryWriterObject { _id = "test-fb-rt", Vector = new[] { 1.5f, -2.5f, 3.5f } };
+		var collection = fixture.Database.GetCollection<FloatBinaryWriterObject>("serializationTest3");
+		var commandOptions = new CommandOptions() { OutputConverter = new DocumentConverter<FloatBinaryWriterObject>() };
+		string serialized = collection.CheckSerialization(original, commandOptions);
+		var deserialized = collection.CheckDeserialization(serialized, commandOptions);
+		Assert.NotNull(deserialized.Vector);
+		Assert.Equal(original.Vector, deserialized.Vector);
+	}
+
 
 }
 


### PR DESCRIPTION
Completes Pre-GA portion of #49 (and #67). Also might eliminate need for DataAPIVector given serialization options available.

1. $binary is properly deserialized for float[] properties

2. User can control how float arrays are serialized via attributes on the properties:

```
public class FloatArrayWriterObject
{
    [DocumentId]
    public string _id { get; set; }
    [JsonConverter(typeof(FloatArrayWriter))]
    public float[] Vector { get; set; }
}

public class FloatBinaryWriterObject
{
    [DocumentId]
    public string _id { get; set; }
    [JsonConverter(typeof(FloatBinaryWriter))]
    public float[] Vector { get; set; }
}
```

Fixes #49 .