### PR TITLE
Enable options to index creation on maps (solves issue 122)

### DIFF
--- a/src/DataStax.AstraDB.DataApi/Tables/TableIndexBuilder.cs
+++ b/src/DataStax.AstraDB.DataApi/Tables/TableIndexBuilder.cs
@@ -26,18 +26,17 @@ public class TableIndexBuilder
     /// <summary>
     /// Create a default table index.
     /// </summary>
-    /// <param name="caseSensitive">Whether the index should be case sensitive</param>
-    /// <param name="normalize">Whether the index should normalize the text</param>
-    /// <param name="ascii">Whether the index should use ASCII conversion</param>
-    /// <returns>An index definition for use in a <see cref="Table"/> CreateIndex method call.</returns>
-    public TableIndexDefinition Index(bool caseSensitive = true, bool normalize = false, bool ascii = false)
+    /// <param name="options">A <see cref="TableIndexOptions"/> specification for the indexing options. Pass null for defaults</param>
+    /// <returns>An index definition for use in a <see cref="Table{T}"/> CreateIndex method call.</returns>
+    public TableIndexDefinition Index(TableIndexOptions options = null)
     {
         return new TableIndexDefinition
         {
-            Options = new TableIndexOptions {
-                CaseSensitive = caseSensitive,
-                Normalize = normalize,
-                Ascii = ascii
+            Options = options ?? new TableIndexOptions
+            {
+                CaseSensitive = true,
+                Normalize = false,
+                Ascii = false
             }
         };
     }
@@ -46,7 +45,7 @@ public class TableIndexBuilder
     /// Create a table index for a map column.
     /// </summary>
     /// <param name="mapIndexType">A <see cref="MapIndexType"/> value specifying how the map is indexed (keys, values or entries).</param>
-    /// <returns>An index definition for use in a <see cref="Table"/> CreateIndex method call.</returns>
+    /// <returns>An index definition for use in a <see cref="Table{T}"/> CreateIndex method call.</returns>
     public TableIndexDefinition Map(MapIndexType mapIndexType)
     {
         return new TableMapIndexDefinition(mapIndexType);
@@ -56,18 +55,17 @@ public class TableIndexBuilder
     /// Create a table index for a map column.
     /// </summary>
     /// <param name="mapIndexType">A <see cref="MapIndexType"/> value specifying how the map is indexed (keys, values or entries).</param>
-    /// <param name="caseSensitive">Whether the index should be case sensitive</param>
-    /// <param name="normalize">Whether the index should normalize the text</param>
-    /// <param name="ascii">Whether the index should use ASCII conversion</param>
-    /// <returns>An index definition for use in a <see cref="Table"/> CreateIndex method call.</returns>
-    public TableIndexDefinition Map(MapIndexType mapIndexType, bool caseSensitive = true, bool normalize = false, bool ascii = false)
+    /// <param name="options">A <see cref="TableIndexOptions"/> specification for the indexing options. Pass null for defaults</param>
+    /// <returns>An index definition for use in a <see cref="Table{T}"/> CreateIndex method call.</returns>
+    public TableIndexDefinition Map(MapIndexType mapIndexType, TableIndexOptions options = null)
     {
-        return new TableMapIndexDefinition (
+        return new TableMapIndexDefinition(
             mapIndexType,
-            new TableIndexOptions {
-                CaseSensitive = caseSensitive,
-                Normalize = normalize,
-                Ascii = ascii
+            options ?? new TableIndexOptions
+            {
+                CaseSensitive = true,
+                Normalize = false,
+                Ascii = false
             }
         );
     }
@@ -75,7 +73,7 @@ public class TableIndexBuilder
     /// <summary>
     /// Create a table text index using the default analyzer.
     /// </summary>
-    /// <returns>An index definition for use in a <see cref="Table"/> CreateIndex method call.</returns>
+    /// <returns>An index definition for use in a <see cref="Table{T}"/> CreateIndex method call.</returns>
     public TableTextIndexDefinition Text()
     {
         return new TableTextIndexDefinition();
@@ -86,7 +84,7 @@ public class TableIndexBuilder
     /// See https://docs.datastax.com/en/astra-db-serverless/databases/analyzers.html#supported-built-in-analyzers
     /// </summary>
     /// <param name="analyzer">A <see cref="TextAnalyzer"/> value specifying a preset indexing method.</param>
-    /// <returns>An index definition for use in a <see cref="Table"/> CreateIndex method call.</returns>
+    /// <returns>An index definition for use in a <see cref="Table{T}"/> CreateIndex method call.</returns>
     public TableTextIndexDefinition Text(TextAnalyzer analyzer)
     {
         return new TableTextIndexDefinition()
@@ -102,7 +100,7 @@ public class TableIndexBuilder
     /// See https://docs.datastax.com/en/astra-db-serverless/databases/analyzers.html#supported-built-in-analyzers
     /// </summary>
     /// <param name="analyzer">A string value specifying a preset indexing method.</param>
-    /// <returns>An index definition for use in a <see cref="Table"/> CreateIndex method call.</returns>
+    /// <returns>An index definition for use in a <see cref="Table{T}"/> CreateIndex method call.</returns>
     public TableTextIndexDefinition Text(string analyzer)
     {
         return new TableTextIndexDefinition()
@@ -118,7 +116,7 @@ public class TableIndexBuilder
     /// See https://docs.datastax.com/en/astra-db-serverless/databases/analyzers.html#supported-built-in-analyzers
     /// </summary>
     /// <param name="analyzerOptions">An <see cref="AnalyzerOptions"/> object defining the analyzer options for the indexing.</param>
-    /// <returns>An index definition for use in a <see cref="Table"/> CreateIndex method call.</returns>
+    /// <returns>An index definition for use in a <see cref="Table{T}"/> CreateIndex method call.</returns>
     public TableTextIndexDefinition Text(AnalyzerOptions analyzerOptions)
     {
         return new TableTextIndexDefinition()
@@ -134,7 +132,7 @@ public class TableIndexBuilder
     /// See https://docs.datastax.com/en/astra-db-serverless/databases/analyzers.html#supported-built-in-analyzers
     /// </summary>
     /// <param name="analyzer">A free-form object defining the analyzer options for the indexing.</param>
-    /// <returns>An index definition for use in a <see cref="Table"/> CreateIndex method call.</returns>
+    /// <returns>An index definition for use in a <see cref="Table{T}"/> CreateIndex method call.</returns>
     public TableTextIndexDefinition Text(object analyzer)
     {
         return new TableTextIndexDefinition()
@@ -148,7 +146,7 @@ public class TableIndexBuilder
     /// <summary>
     /// Create a table vector index.
     /// </summary>
-    /// <returns>An index definition for use in a <see cref="Table"/> CreateIndex method call.</returns>
+    /// <returns>An index definition for use in a <see cref="Table{T}"/> CreateIndex method call.</returns>
     public TableVectorIndexDefinition Vector()
     {
         return Vector(null, null);
@@ -158,7 +156,7 @@ public class TableIndexBuilder
     /// Create a table vector index.
     /// </summary>
     /// <param name="metric">Similarity metric to use for vector searches on this index</param>
-    /// <returns>An index definition for use in a <see cref="Table"/> CreateIndex method call.</returns>
+    /// <returns>An index definition for use in a <see cref="Table{T}"/> CreateIndex method call.</returns>
     public TableVectorIndexDefinition Vector(SimilarityMetric metric)
     {
         return Vector(metric, null);
@@ -168,7 +166,7 @@ public class TableIndexBuilder
     /// Create a table vector index.
     /// </summary>
     /// <param name="sourceModel">Allows enabling certain vector optimizations on the index by specifying the source model for your vectors</param>
-    /// <returns>An index definition for use in a <see cref="Table"/> CreateIndex method call.</returns>
+    /// <returns>An index definition for use in a <see cref="Table{T}"/> CreateIndex method call.</returns>
     public TableVectorIndexDefinition Vector(string sourceModel)
     {
         return Vector(null, sourceModel);
@@ -179,7 +177,7 @@ public class TableIndexBuilder
     /// </summary>
     /// <param name="metric">Similarity metric to use for vector searches on this index</param>
     /// <param name="sourceModel">Allows enabling certain vector optimizations on the index by specifying the source model for your vectors. Pass a null for server default.</param>
-    /// <returns>An index definition for use in a <see cref="Table"/> CreateIndex method call.</returns>
+    /// <returns>An index definition for use in a <see cref="Table{T}"/> CreateIndex method call.</returns>
     public TableVectorIndexDefinition Vector(SimilarityMetric? metric, string sourceModel)
     {
         return new TableVectorIndexDefinition

--- a/src/DataStax.AstraDB.DataApi/Tables/TableIndexBuilder.cs
+++ b/src/DataStax.AstraDB.DataApi/Tables/TableIndexBuilder.cs
@@ -24,9 +24,12 @@ namespace DataStax.AstraDB.DataApi.Tables;
 public class TableIndexBuilder
 {
     /// <summary>
-    /// Create a default index.
+    /// Create a default table index.
     /// </summary>
-    /// <returns></returns>
+    /// <param name="caseSensitive">Whether the index should be case sensitive</param>
+    /// <param name="normalize">Whether the index should normalize the text</param>
+    /// <param name="ascii">Whether the index should use ASCII conversion</param>
+    /// <returns>An index definition for use in a <see cref="Table"/> CreateIndex method call.</returns>
     public TableIndexDefinition Index(bool caseSensitive = true, bool normalize = false, bool ascii = false)
     {
         return new TableIndexDefinition
@@ -42,27 +45,48 @@ public class TableIndexBuilder
     /// <summary>
     /// Create a table index for a map column.
     /// </summary>
-    /// <param name="mapIndexType"></param>
-    /// <returns></returns>
+    /// <param name="mapIndexType">A <see cref="MapIndexType"/> value specifying how the map is indexed (keys, values or entries).</param>
+    /// <returns>An index definition for use in a <see cref="Table"/> CreateIndex method call.</returns>
     public TableIndexDefinition Map(MapIndexType mapIndexType)
     {
         return new TableMapIndexDefinition(mapIndexType);
     }
 
     /// <summary>
-    /// Create a text index using the default analyzer.
+    /// Create a table index for a map column.
     /// </summary>
-    /// <returns></returns>
+    /// <param name="mapIndexType">A <see cref="MapIndexType"/> value specifying how the map is indexed (keys, values or entries).</param>
+    /// <param name="caseSensitive">Whether the index should be case sensitive</param>
+    /// <param name="normalize">Whether the index should normalize the text</param>
+    /// <param name="ascii">Whether the index should use ASCII conversion</param>
+    /// <returns>An index definition for use in a <see cref="Table"/> CreateIndex method call.</returns>
+    public TableIndexDefinition Map(MapIndexType mapIndexType, bool caseSensitive = true, bool normalize = false, bool ascii = false)
+    {
+        return new TableMapIndexDefinition (
+            mapIndexType,
+            new TableIndexOptions {
+                CaseSensitive = caseSensitive,
+                Normalize = normalize,
+                Ascii = ascii
+            }
+        );
+    }
+
+    /// <summary>
+    /// Create a table text index using the default analyzer.
+    /// </summary>
+    /// <returns>An index definition for use in a <see cref="Table"/> CreateIndex method call.</returns>
     public TableTextIndexDefinition Text()
     {
         return new TableTextIndexDefinition();
     }
 
     /// <summary>
-    /// Create a text index using a specific analyzer.
+    /// Create a table text index using a specific analyzer.
+    /// See https://docs.datastax.com/en/astra-db-serverless/databases/analyzers.html#supported-built-in-analyzers
     /// </summary>
-    /// <param name="analyzer"></param>
-    /// <returns></returns>
+    /// <param name="analyzer">A <see cref="TextAnalyzer"/> value specifying a preset indexing method.</param>
+    /// <returns>An index definition for use in a <see cref="Table"/> CreateIndex method call.</returns>
     public TableTextIndexDefinition Text(TextAnalyzer analyzer)
     {
         return new TableTextIndexDefinition()
@@ -74,11 +98,11 @@ public class TableIndexBuilder
     }
 
     /// <summary>
-    /// Create a text index using a specific analyzer by name, for example a language-specific analyzer.
+    /// Create a table text index using a specific analyzer by name, for example a language-specific analyzer.
     /// See https://docs.datastax.com/en/astra-db-serverless/databases/analyzers.html#supported-built-in-analyzers
     /// </summary>
-    /// <param name="analyzer"></param>
-    /// <returns></returns>
+    /// <param name="analyzer">A string value specifying a preset indexing method.</param>
+    /// <returns>An index definition for use in a <see cref="Table"/> CreateIndex method call.</returns>
     public TableTextIndexDefinition Text(string analyzer)
     {
         return new TableTextIndexDefinition()
@@ -90,10 +114,11 @@ public class TableIndexBuilder
     }
 
     /// <summary>
-    /// Create a text index using custom analyzer options.
+    /// Create a table text index using custom analyzer options.
+    /// See https://docs.datastax.com/en/astra-db-serverless/databases/analyzers.html#supported-built-in-analyzers
     /// </summary>
-    /// <param name="analyzerOptions"></param>
-    /// <returns></returns>
+    /// <param name="analyzerOptions">An <see cref="AnalyzerOptions"/> object defining the analyzer options for the indexing.</param>
+    /// <returns>An index definition for use in a <see cref="Table"/> CreateIndex method call.</returns>
     public TableTextIndexDefinition Text(AnalyzerOptions analyzerOptions)
     {
         return new TableTextIndexDefinition()
@@ -105,10 +130,11 @@ public class TableIndexBuilder
     }
 
     /// <summary>
-    /// Create a text index with free-form analyzer options.
+    /// Create a table text index using custom, free-form analyzer options.
+    /// See https://docs.datastax.com/en/astra-db-serverless/databases/analyzers.html#supported-built-in-analyzers
     /// </summary>
-    /// <param name="analyzer"></param>
-    /// <returns></returns>
+    /// <param name="analyzer">A free-form object defining the analyzer options for the indexing.</param>
+    /// <returns>An index definition for use in a <see cref="Table"/> CreateIndex method call.</returns>
     public TableTextIndexDefinition Text(object analyzer)
     {
         return new TableTextIndexDefinition()
@@ -120,40 +146,40 @@ public class TableIndexBuilder
     }
 
     /// <summary>
-    /// Create a vector index.
+    /// Create a table vector index.
     /// </summary>
-    /// <returns></returns>
+    /// <returns>An index definition for use in a <see cref="Table"/> CreateIndex method call.</returns>
     public TableVectorIndexDefinition Vector()
     {
         return Vector(null, null);
     }
 
     /// <summary>
-    /// Create a vector index.
+    /// Create a table vector index.
     /// </summary>
-    /// <param name="metric">Optional similarity metric to use for vector searches on this index</param>
-    /// <returns></returns>
+    /// <param name="metric">Similarity metric to use for vector searches on this index</param>
+    /// <returns>An index definition for use in a <see cref="Table"/> CreateIndex method call.</returns>
     public TableVectorIndexDefinition Vector(SimilarityMetric metric)
     {
         return Vector(metric, null);
     }
 
     /// <summary>
-    /// Create a vector index.
+    /// Create a table vector index.
     /// </summary>
     /// <param name="sourceModel">Allows enabling certain vector optimizations on the index by specifying the source model for your vectors</param>
-    /// <returns></returns>
+    /// <returns>An index definition for use in a <see cref="Table"/> CreateIndex method call.</returns>
     public TableVectorIndexDefinition Vector(string sourceModel)
     {
         return Vector(null, sourceModel);
     }
 
     /// <summary>
-    /// Create a vector index.
+    /// Create a table vector index.
     /// </summary>
     /// <param name="metric">Similarity metric to use for vector searches on this index</param>
     /// <param name="sourceModel">Allows enabling certain vector optimizations on the index by specifying the source model for your vectors. Pass a null for server default.</param>
-    /// <returns></returns>
+    /// <returns>An index definition for use in a <see cref="Table"/> CreateIndex method call.</returns>
     public TableVectorIndexDefinition Vector(SimilarityMetric? metric, string sourceModel)
     {
         return new TableVectorIndexDefinition

--- a/src/DataStax.AstraDB.DataApi/Tables/TableMapIndexDefinition.cs
+++ b/src/DataStax.AstraDB.DataApi/Tables/TableMapIndexDefinition.cs
@@ -49,6 +49,12 @@ public class TableMapIndexDefinition : TableIndexDefinition
         IndexType = indexType;
     }
 
+    internal TableMapIndexDefinition(MapIndexType indexType, TableIndexOptions options)
+    {
+        IndexType = indexType;
+        Options = options;
+    }
+
     /// <summary>
     /// The column to index.
     /// </summary>

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/TableIndexesTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/TableIndexesTests.cs
@@ -260,9 +260,9 @@ public class TableIndexesTests
     }
 
     [Fact]
-    public async Task CreateIndexTests_MapIndex_Keys()
+    public async Task CreateIndexTests_MapIndex_KeysNoOptions()
     {
-        var tableName = "tableIndexesTest_MapIndex_Keys";
+        var tableName = "CreateIndexTests_MapIndex_KeysNoOptions";
         string indexName = "map_k_idx";
 
         try
@@ -286,9 +286,41 @@ public class TableIndexesTests
     }
 
     [Fact]
-    public async Task CreateIndexTests_MapIndex_Values()
+    public async Task CreateIndexTests_MapIndex_KeysWithOptions()
     {
-        var tableName = "tableIndexesTest_MapIndex_Values";
+        var tableName = "CreateIndexTests_MapIndex_KeysWithOptions";
+        string indexName = "map_k_idx";
+
+        try
+        {
+            var table = await fixture.Database.CreateTableAsync<TableMapTest>(tableName);
+
+            await table.CreateIndexAsync(indexName, (b) => b.StringMap,
+                Builders.TableIndex.Map(MapIndexType.Keys, true, true, true));
+            // compare: {"createIndex":{"name":"map_k_idx","definition":{"column":{"StringMap":"$keys"},"options":{"caseSensitive":true,"normalize":true,"ascii":true}}}}
+
+            var result = await table.ListIndexesAsync();
+            var foundIndex = result.Indexes.Single(i => i.Name == indexName);
+            Assert.NotNull(foundIndex);
+            Assert.IsType<TableIndexDefinition>(foundIndex.Definition);
+            Assert.Equal(new Dictionary<string,string> { ["StringMap"] = "$keys" }, foundIndex.Definition.Column);
+            var indexDefinition = (TableIndexDefinition)foundIndex.Definition;
+            Assert.NotNull(indexDefinition.Options);
+            Assert.True(indexDefinition.Options.CaseSensitive);
+            Assert.True(indexDefinition.Options.Normalize);
+            Assert.True(indexDefinition.Options.Ascii);
+
+        }
+        finally
+        {
+            await fixture.Database.DropTableAsync(tableName);
+        }
+    }
+
+    [Fact]
+    public async Task CreateIndexTests_MapIndex_ValuesNoOptions()
+    {
+        var tableName = "CreateIndexTests_MapIndex_ValuesNoOptions";
         string indexName = "map_v_idx";
 
         try
@@ -303,6 +335,38 @@ public class TableIndexesTests
             Assert.NotNull(foundIndex);
             Assert.IsType<TableIndexDefinition>(foundIndex.Definition);
             Assert.Equal(new Dictionary<string,string> { ["StringMap"] = "$values" }, foundIndex.Definition.Column);
+
+        }
+        finally
+        {
+            await fixture.Database.DropTableAsync(tableName);
+        }
+    }
+
+    [Fact]
+    public async Task CreateIndexTests_MapIndex_ValuesWithOptions()
+    {
+        var tableName = "tableIndexesTest_MapIndex_Values";
+        string indexName = "map_v_idx";
+
+        try
+        {
+            var table = await fixture.Database.CreateTableAsync<TableMapTest>(tableName);
+
+            await table.CreateIndexAsync(indexName, (b) => b.StringMap,
+                Builders.TableIndex.Map(MapIndexType.Values, true, true, true));
+            // compare: {"createIndex":{"name":"map_v_idx","definition":{"column":{"StringMap":"$values"},"options":{"caseSensitive":true,"normalize":true,"ascii":true}}}}
+
+            var result = await table.ListIndexesAsync();
+            var foundIndex = result.Indexes.Single(i => i.Name == indexName);
+            Assert.NotNull(foundIndex);
+            Assert.IsType<TableIndexDefinition>(foundIndex.Definition);
+            Assert.Equal(new Dictionary<string,string> { ["StringMap"] = "$values" }, foundIndex.Definition.Column);
+            var indexDefinition = (TableIndexDefinition)foundIndex.Definition;
+            Assert.NotNull(indexDefinition.Options);
+            Assert.True(indexDefinition.Options.CaseSensitive);
+            Assert.True(indexDefinition.Options.Normalize);
+            Assert.True(indexDefinition.Options.Ascii);
 
         }
         finally

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/TableIndexesTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/TableIndexesTests.cs
@@ -312,7 +312,7 @@ public class TableIndexesTests
             // compare: {"createIndex":{"name":"map_k_idx","definition":{"column":{"StringMap":"$keys"},"options":{"caseSensitive":true,"normalize":true,"ascii":true}}}}
 
             var result = await table.ListIndexesAsync();
-            var foundIndex = result.Indexes.Single(i => i.Name == indexName);
+            var foundIndex = result.Single(i => i.Name == indexName);
             Assert.NotNull(foundIndex);
             Assert.IsType<TableIndexDefinition>(foundIndex.Definition);
             Assert.Equal(new Dictionary<string,string> { ["StringMap"] = "$keys" }, foundIndex.Definition.Column);
@@ -377,7 +377,7 @@ public class TableIndexesTests
             // compare: {"createIndex":{"name":"map_v_idx","definition":{"column":{"StringMap":"$values"},"options":{"caseSensitive":true,"normalize":true,"ascii":true}}}}
 
             var result = await table.ListIndexesAsync();
-            var foundIndex = result.Indexes.Single(i => i.Name == indexName);
+            var foundIndex = result.Single(i => i.Name == indexName);
             Assert.NotNull(foundIndex);
             Assert.IsType<TableIndexDefinition>(foundIndex.Definition);
             Assert.Equal(new Dictionary<string,string> { ["StringMap"] = "$values" }, foundIndex.Definition.Column);
@@ -732,8 +732,7 @@ public class TableIndexesTests
     }
 
     [SkipWhenAstra]
-    // [Fact(Skip="Run manually on HCD after some CQL setup!")]
-    [Fact]
+    [Fact(Skip="Run manually on HCD after some CQL setup!")]
     public async Task ListIndexesTests_UnknownUnsupportedCQLIndex()
     {
         var tableName = "table_with_unsupported_index";

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/TableIndexesTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/TableIndexesTests.cs
@@ -183,10 +183,16 @@ public class TableIndexesTests
         {
             var table = await fixture.Database.CreateTableAsync<RowEventByDay>(tableName);
             string indexName = "category_idx";
-            var indexDefinition = new TableIndexDefinition() { Options = new TableIndexOptions { Ascii = true,  CaseSensitive = true, Normalize = true } };
 
-            await table.CreateIndexAsync(indexName, (b) => b.Category, Builders.TableIndex.Index(true, true, true));
-            // compare: {"createIndex":{"name":"category_idx","definition":{"column":"category","options":{"ascii":true,"caseSensitive":true,"normalize":true}}}}
+            await table.CreateIndexAsync(indexName, (b) => b.Category,
+                Builders.TableIndex.Index(new TableIndexOptions
+                    {
+                        CaseSensitive = true,
+                        Normalize = true,
+                        Ascii = true
+                    }
+                ));
+            // compare: {"createIndex":{"name":"category_idx","definition":{"options":{"caseSensitive":true,"normalize":true,"ascii":true},"column":"category"}}}
 
             var result = await table.ListIndexesAsync();
             var foundIndex = result.Single(i => i.Name == indexName);
@@ -296,7 +302,13 @@ public class TableIndexesTests
             var table = await fixture.Database.CreateTableAsync<TableMapTest>(tableName);
 
             await table.CreateIndexAsync(indexName, (b) => b.StringMap,
-                Builders.TableIndex.Map(MapIndexType.Keys, true, true, true));
+                Builders.TableIndex.Map(MapIndexType.Keys, new TableIndexOptions
+                    {
+                        CaseSensitive = true,
+                        Normalize = true,
+                        Ascii = true
+                    }
+                ));
             // compare: {"createIndex":{"name":"map_k_idx","definition":{"column":{"StringMap":"$keys"},"options":{"caseSensitive":true,"normalize":true,"ascii":true}}}}
 
             var result = await table.ListIndexesAsync();
@@ -353,8 +365,15 @@ public class TableIndexesTests
         {
             var table = await fixture.Database.CreateTableAsync<TableMapTest>(tableName);
 
-            await table.CreateIndexAsync(indexName, (b) => b.StringMap,
-                Builders.TableIndex.Map(MapIndexType.Values, true, true, true));
+            await table.CreateIndexAsync(
+                indexName, (b) => b.StringMap,
+                Builders.TableIndex.Map(MapIndexType.Values, new TableIndexOptions
+                    {
+                        CaseSensitive = true,
+                        Normalize = true,
+                        Ascii = true
+                    }
+                ));
             // compare: {"createIndex":{"name":"map_v_idx","definition":{"column":{"StringMap":"$values"},"options":{"caseSensitive":true,"normalize":true,"ascii":true}}}}
 
             var result = await table.ListIndexesAsync();
@@ -712,8 +731,9 @@ public class TableIndexesTests
 
     }
 
-    // [SkipWhenAstra] // TODO: reinstate this attribute once 115 is merged
-    [Fact(Skip="Run manually on HCD after some CQL setup!")]
+    [SkipWhenAstra]
+    // [Fact(Skip="Run manually on HCD after some CQL setup!")]
+    [Fact]
     public async Task ListIndexesTests_UnknownUnsupportedCQLIndex()
     {
         var tableName = "table_with_unsupported_index";


### PR DESCRIPTION
Fixes #122 .

This PR enables passing the options (ascii/normalize/caseSensitive) to index creation for a _map_ table column.

Along the way:

1. xmldoc params are aligned with the actual methods in TableIndexBuilder (+their text added where it was missing);
2. said options are encapsulated in the proper TableIndexOptions to avoid three anonymous booleans in a row (incl. non-table index creation). **this is a breaking change** (see tests), which anyway we have discussed in 122 already.
3. added tests for this index creation pattern.

_Note_: as a matter of fact, the Data API accepts these options when creating _keys/values indexes only_, whereas for "entries creation" there is only one allowed combination of the three bools (the default), which renders it unnecessary to specify them. However, preventing the user from supplying the options is probably not a task for the client under the philosophy of not duplicating server-side guardrails. Hence no checks are performed ("if mapindextype == entries ...").
