### PR TITLE
Subsume waitForCompletion/updateDBKeyspace into BlockingCommandOptions

### DIFF
--- a/src/DataStax.AstraDB.DataApi/Admin/AstraDatabasesAdmin.cs
+++ b/src/DataStax.AstraDB.DataApi/Admin/AstraDatabasesAdmin.cs
@@ -414,7 +414,7 @@ public class AstraDatabasesAdmin
     }
 
     /// <summary>
-    /// Synchronous version of <see cref="DropDatabaseAsync(string, CommandOptions)"/>.
+    /// Synchronous version of <see cref="DropDatabaseAsync(string, BlockingCommandOptions)"/>.
     /// </summary>
     public void DropDatabase(string dbGuid, BlockingCommandOptions commandOptions)
     {
@@ -439,9 +439,11 @@ public class AstraDatabasesAdmin
         return DropDatabaseAsync(dbGuid, null);
     }
 
-    /// <inheritdoc cref="DropDatabaseAsync(string)"/>
+    /// <summary>
+    /// Drops the database with the specified ID.
+    /// </summary>
     /// <param name="dbGuid">The ID of the database to drop.</param>
-    /// <param name="options">The command options to use.</param>
+    /// <param name="commandOptions">The command options to use.</param>
     /// <example>
     /// <code>
     /// await admin.DropDatabaseAsync("a1b2c3d4-e5f6-7890-abcd-ef1234567890", options);

--- a/src/DataStax.AstraDB.DataApi/Admin/AstraDatabasesAdmin.cs
+++ b/src/DataStax.AstraDB.DataApi/Admin/AstraDatabasesAdmin.cs
@@ -270,71 +270,27 @@ public class AstraDatabasesAdmin
     }
 
     /// <summary>
-    /// Creates a new database with the specified creation options.
+    /// Synchronous version of <see cref="CreateDatabaseAsync(DatabaseCreationOptions)"/>
     /// </summary>
-    /// <param name="options">The database creation options.</param>
-    /// <returns>An IDatabaseAdmin instance for the created database.</returns>
-    /// <example>
-    /// <code>
-    /// var adminDb = admin.CreateDatabase(new (){Name="MyDB", CloudProvider=CloudProviderType.AWS, Region="us-east-2"});
-    /// </code>
-    /// </example>
-    public IDatabaseAdmin CreateDatabase(DatabaseCreationOptions options)
+    /// <remarks>
+    /// This method, by default, will wait for the operation to complete on the server side.
+    /// Use the options' waitForCompletion attribute to control this behaviour.
+    /// </remarks>
+    public IDatabaseAdmin CreateDatabase(DatabaseCreationOptions creationOptions)
     {
-        return CreateDatabaseAsync(options, true, null, true).ResultSync();
+        return CreateDatabase(creationOptions, null);
+    }
+
+    /// <summary>
+    /// Synchronous version of <see cref="CreateDatabaseAsync(DatabaseCreationOptions, BlockingCommandOptions)"/>
+    /// </summary>
+    public IDatabaseAdmin CreateDatabase(DatabaseCreationOptions creationOptions, BlockingCommandOptions commandOptions)
+    {
+        return CreateDatabaseAsync(creationOptions, commandOptions, true).ResultSync();
     }
 
     /// <summary>
     /// Creates a new database with the specified creation options.
-    /// </summary>
-    /// <param name="options">The database creation options.</param>
-    /// <param name="waitForDb">Whether to wait until the database becomes active.</param>
-    /// <returns>An IDatabaseAdmin instance for the created database.</returns>
-    /// <example>
-    /// <code>
-    /// var adminDb = admin.CreateDatabase(new (){Name="MyDB", CloudProvider=CloudProviderType.AWS, Region="us-east-2"});
-    /// </code>
-    /// </example>
-    public IDatabaseAdmin CreateDatabase(DatabaseCreationOptions options, bool waitForDb)
-    {
-        return CreateDatabaseAsync(options, waitForDb, null, true).ResultSync();
-    }
-
-    /// <summary>
-    /// Creates a new database with the specified creation and command options.
-    /// </summary>
-    /// <param name="options">The database creation options.</param>
-    /// <param name="commandOptions">Additional command options.</param>
-    /// <returns>An IDatabaseAdmin instance for the created database.</returns>
-    /// <example>
-    /// <code>
-    /// var adminDb = admin.CreateDatabase(new (){Name="MyDB", CloudProvider=CloudProviderType.AWS, Region="us-east-2"}, commandOptions);
-    /// </code>
-    /// </example>
-    public IDatabaseAdmin CreateDatabase(DatabaseCreationOptions options, CommandOptions commandOptions)
-    {
-        return CreateDatabaseAsync(options, true, commandOptions, true).ResultSync();
-    }
-
-    /// <summary>
-    /// Creates a new database with the specified creation and command options.
-    /// </summary>
-    /// <param name="options">The database creation options.</param>
-    /// <param name="commandOptions">Additional command options.</param>
-    /// <param name="waitForDb">Whether to wait until the database becomes active.</param>
-    /// <returns>An IDatabaseAdmin instance for the created database.</returns>
-    /// <example>
-    /// <code>
-    /// var adminDb = admin.CreateDatabase(new (){Name="MyDB", CloudProvider=CloudProviderType.AWS, Region="us-east-2"}, commandOptions);
-    /// </code>
-    /// </example>
-    public IDatabaseAdmin CreateDatabase(DatabaseCreationOptions options, bool waitForDb, CommandOptions commandOptions)
-    {
-        return CreateDatabaseAsync(options, waitForDb, commandOptions, true).ResultSync();
-    }
-
-    /// <summary>
-    /// Asynchronously creates a new database with the specified creation options.
     /// </summary>
     /// <param name="creationOptions">The database creation options.</param>
     /// <returns>A task that resolves to an IDatabaseAdmin instance for the created database.</returns>
@@ -343,62 +299,34 @@ public class AstraDatabasesAdmin
     /// var adminDb = await admin.CreateDatabaseAsync(new (){Name="MyDB", CloudProvider=CloudProviderType.AWS, Region="us-east-2"});
     /// </code>
     /// </example>
+    /// <remarks>
+    /// This method, by default, will wait for the operation to complete on the server side.
+    /// Use the options' waitForCompletion attribute to control this behaviour.
+    /// </remarks>
     public Task<IDatabaseAdmin> CreateDatabaseAsync(DatabaseCreationOptions creationOptions)
     {
-        return CreateDatabaseAsync(creationOptions, true, null, false);
+        return CreateDatabaseAsync(creationOptions, null);
     }
 
     /// <summary>
-    /// Asynchronously creates a new database with the specified creation options.
+    /// Creates a new database with the specified creation and command options.
     /// </summary>
     /// <param name="creationOptions">The database creation options.</param>
-    /// <param name="waitForDb">Whether to wait until the database becomes active.</param>
-    /// <returns>A task that resolves to an IDatabaseAdmin instance for the created database.</returns>
-    /// <example>
-    /// <code>
-    /// var adminDb = await admin.CreateDatabaseAsync(new (){Name="MyDB", CloudProvider=CloudProviderType.AWS, Region="us-east-2"});
-    /// </code>
-    /// </example>
-    public Task<IDatabaseAdmin> CreateDatabaseAsync(DatabaseCreationOptions creationOptions, bool waitForDb)
-    {
-        return CreateDatabaseAsync(creationOptions, waitForDb, null, false);
-    }
-
-    /// <summary>
-    /// Asynchronously creates a new database with the specified creation and command options.
-    /// </summary>
-    /// <param name="creationOptions">The database creation options.</param>
-    /// <param name="commandOptions">Additional command options.</param>
+    /// <param name="commandOptions">Optional settings that influence request execution.</param>
     /// <returns>A task that resolves to an IDatabaseAdmin instance for the created database.</returns>
     /// <example>
     /// <code>
     /// var adminDb = await admin.CreateDatabaseAsync(new (){Name="MyDB", CloudProvider=CloudProviderType.AWS, Region="us-east-2"}, commandOptions);
     /// </code>
     /// </example>
-    public Task<IDatabaseAdmin> CreateDatabaseAsync(DatabaseCreationOptions creationOptions, CommandOptions commandOptions)
+    public Task<IDatabaseAdmin> CreateDatabaseAsync(DatabaseCreationOptions creationOptions, BlockingCommandOptions commandOptions)
     {
-        return CreateDatabaseAsync(creationOptions, true, commandOptions, false);
+        return CreateDatabaseAsync(creationOptions, commandOptions, false);
     }
 
-    /// <summary>
-    /// Asynchronously creates a new database with the specified creation and command options.
-    /// </summary>
-    /// <param name="creationOptions">The database creation options.</param>
-    /// <param name="waitForDb">Whether to wait until the database becomes active.</param>
-    /// <param name="commandOptions">Additional command options.</param>
-    /// <returns>A task that resolves to an IDatabaseAdmin instance for the created database.</returns>
-    /// <example>
-    /// <code>
-    /// var adminDb = await admin.CreateDatabaseAsync(new (){Name="MyDB", CloudProvider=CloudProviderType.AWS, Region="us-east-2"}, commandOptions);
-    /// </code>
-    /// </example>
-    public Task<IDatabaseAdmin> CreateDatabaseAsync(DatabaseCreationOptions creationOptions, bool waitForDb, CommandOptions commandOptions)
+    internal async Task<IDatabaseAdmin> CreateDatabaseAsync(DatabaseCreationOptions creationOptions, BlockingCommandOptions commandOptions, bool runSynchronously)
     {
-        return CreateDatabaseAsync(creationOptions, waitForDb, commandOptions, false);
-    }
-
-    internal async Task<IDatabaseAdmin> CreateDatabaseAsync(DatabaseCreationOptions creationOptions, bool waitForDb, CommandOptions commandOptions, bool runSynchronously)
-    {
+        commandOptions ??= new BlockingCommandOptions();
         Guard.NotNullOrEmpty(creationOptions.Name, nameof(creationOptions.Name));
         Guard.NotNull(creationOptions.CloudProvider, nameof(creationOptions.CloudProvider));
         Guard.NotNullOrEmpty(creationOptions.Region, nameof(creationOptions.Region));
@@ -419,7 +347,7 @@ public class AstraDatabasesAdmin
         };
         await command.RunAsyncRaw<Command.EmptyResult>(runSynchronously).ConfigureAwait(false);
 
-        if (waitForDb)
+        if (commandOptions.waitForCompletion)
         {
             if (runSynchronously)
             {
@@ -474,135 +402,59 @@ public class AstraDatabasesAdmin
     }
 
     /// <summary>
-    /// Drops the database with the specified ID.
+    /// Synchronous version of <see cref="DropDatabaseAsync(string)"/>.
     /// </summary>
-    /// <param name="dbGuid">The ID of the database to drop.</param>
-    /// <returns>True if the database was dropped successfully; otherwise, false.</returns>
-    /// <example>
-    /// <code>
-    /// bool dropped = admin.DropDatabase("a1b2c3d4-e5f6-7890-abcd-ef1234567890");
-    /// </code>
-    /// </example>
-    public bool DropDatabase(string dbGuid)
+    /// <remarks>
+    /// This method, by default, will wait for the operation to complete on the server side.
+    /// Use the options' waitForCompletion attribute to control this behaviour.
+    /// </remarks>
+    public void DropDatabase(string dbGuid)
     {
-        return DropDatabaseAsync(dbGuid, true, null, false).ResultSync();
+        DropDatabase(dbGuid, null);
+    }
+
+    /// <summary>
+    /// Synchronous version of <see cref="DropDatabaseAsync(string, CommandOptions)"/>.
+    /// </summary>
+    public void DropDatabase(string dbGuid, BlockingCommandOptions commandOptions)
+    {
+        DropDatabaseAsync(dbGuid, commandOptions, true).ResultSync();
     }
 
     /// <summary>
     /// Drops the database with the specified ID.
     /// </summary>
     /// <param name="dbGuid">The ID of the database to drop.</param>
-    /// <param name="waitForDb">Whether to wait until the database is terminated.</param>
-    /// <returns>True if the database was dropped successfully; otherwise, false.</returns>
     /// <example>
     /// <code>
-    /// bool dropped = admin.DropDatabase("a1b2c3d4-e5f6-7890-abcd-ef1234567890");
+    /// await admin.DropDatabaseAsync("a1b2c3d4-e5f6-7890-abcd-ef1234567890");
     /// </code>
     /// </example>
-    public bool DropDatabase(string dbGuid, bool waitForDb)
+    /// <remarks>
+    /// This method, by default, will wait for the operation to complete on the server side.
+    /// Use the options' waitForCompletion attribute to control this behaviour.
+    /// </remarks>
+    public Task DropDatabaseAsync(string dbGuid)
     {
-        return DropDatabaseAsync(dbGuid, waitForDb, null, false).ResultSync();
+        return DropDatabaseAsync(dbGuid, null);
     }
 
-    /// <summary>
-    /// Drops the database with the specified ID using provided command options.
-    /// </summary>
-    /// <param name="dbGuid">The ID of the database to drop.</param>
-    /// <param name="options"></param>
-    /// <returns>True if the database was dropped successfully; otherwise, false.</returns>
-    /// <example>
-    /// <code>
-    /// bool dropped = admin.DropDatabase("a1b2c3d4-e5f6-7890-abcd-ef1234567890", options);
-    /// </code>
-    /// </example>
-    public bool DropDatabase(string dbGuid, CommandOptions options)
-    {
-        return DropDatabaseAsync(dbGuid, true, options, false).ResultSync();
-    }
-
-    /// <summary>
-    /// Drops the database with the specified ID using provided command options.
-    /// </summary>
-    /// <param name="dbGuid">The ID of the database to drop.</param>
-    /// <param name="waitForDb">Whether to wait until the database is terminated.</param>
-    /// <param name="options"></param>
-    /// <returns>True if the database was dropped successfully; otherwise, false.</returns>
-    /// <example>
-    /// <code>
-    /// bool dropped = admin.DropDatabase("a1b2c3d4-e5f6-7890-abcd-ef1234567890", options);
-    /// </code>
-    /// </example>
-    public bool DropDatabase(string dbGuid, bool waitForDb, CommandOptions options)
-    {
-        return DropDatabaseAsync(dbGuid, waitForDb, options, false).ResultSync();
-    }
-
-    /// <summary>
-    /// Asynchronously drops the database with the specified ID.
-    /// </summary>
-    /// <param name="dbGuid">The ID of the database to drop.</param>
-    /// <returns>A task that resolves to true if the database was dropped successfully; otherwise, false.</returns>
-    /// <example>
-    /// <code>
-    /// bool dropped = await admin.DropDatabaseAsync("a1b2c3d4-e5f6-7890-abcd-ef1234567890");
-    /// </code>
-    /// </example>
-    public Task<bool> DropDatabaseAsync(string dbGuid)
-    {
-        return DropDatabaseAsync(dbGuid, true, null, true);
-    }
-
-    /// <summary>
-    /// Asynchronously drops the database with the specified ID.
-    /// </summary>
-    /// <param name="dbGuid">The ID of the database to drop.</param>
-    /// <param name="waitForDb">Whether to wait until the database is terminated.</param>
-    /// <returns>A task that resolves to true if the database was dropped successfully; otherwise, false.</returns>
-    /// <example>
-    /// <code>
-    /// bool dropped = await admin.DropDatabaseAsync("a1b2c3d4-e5f6-7890-abcd-ef1234567890");
-    /// </code>
-    /// </example>
-    public Task<bool> DropDatabaseAsync(string dbGuid, bool waitForDb)
-    {
-        return DropDatabaseAsync(dbGuid, waitForDb, null, true);
-    }
-
-    /// <summary>
-    /// Asynchronously drops the database with the specified ID using provided command options.
-    /// </summary>
+    /// <inheritdoc cref="DropDatabaseAsync(string)"/>
     /// <param name="dbGuid">The ID of the database to drop.</param>
     /// <param name="options">The command options to use.</param>
-    /// <returns>A task that resolves to true if the database was dropped successfully; otherwise, false.</returns>
     /// <example>
     /// <code>
-    /// bool dropped = await admin.DropDatabaseAsync("a1b2c3d4-e5f6-7890-abcd-ef1234567890", options);
+    /// await admin.DropDatabaseAsync("a1b2c3d4-e5f6-7890-abcd-ef1234567890", options);
     /// </code>
     /// </example>
-    public Task<bool> DropDatabaseAsync(string dbGuid, CommandOptions options)
+    public Task DropDatabaseAsync(string dbGuid, BlockingCommandOptions commandOptions)
     {
-        return DropDatabaseAsync(dbGuid, true, options, true);
+        return DropDatabaseAsync(dbGuid, commandOptions, true);
     }
 
-    /// <summary>
-    /// Asynchronously drops the database with the specified ID using provided command options.
-    /// </summary>
-    /// <param name="dbGuid">The ID of the database to drop.</param>
-    /// <param name="options">The command options to use.</param>
-    /// <param name="waitForDb">Whether to wait until the database is terminated.</param>
-    /// <returns>A task that resolves to true if the database was dropped successfully; otherwise, false.</returns>
-    /// <example>
-    /// <code>
-    /// bool dropped = await admin.DropDatabaseAsync("a1b2c3d4-e5f6-7890-abcd-ef1234567890", options);
-    /// </code>
-    /// </example>
-    public Task<bool> DropDatabaseAsync(string dbGuid, bool waitForDb, CommandOptions options)
+    internal async Task DropDatabaseAsync(string dbGuid, BlockingCommandOptions options, bool runSynchronously)
     {
-        return DropDatabaseAsync(dbGuid, waitForDb, options, true);
-    }
-
-    internal async Task<bool> DropDatabaseAsync(string dbGuid, bool waitForDb, CommandOptions options, bool runSynchronously)
-    {
+        options ??= new BlockingCommandOptions();
         Guard.NotNullOrEmpty(dbGuid, nameof(dbGuid));
         Command command = CreateCommand()
             .AddUrlPath("databases")
@@ -613,7 +465,7 @@ public class AstraDatabasesAdmin
 
         await command.RunAsyncRaw<Command.EmptyResult>(runSynchronously).ConfigureAwait(false);
 
-        if (waitForDb)
+        if (options.waitForCompletion)
         {
             if (runSynchronously)
             {
@@ -624,8 +476,6 @@ public class AstraDatabasesAdmin
                 await WaitForDatabaseAsync(dbGuid, _droppingDatabaseStatuses, AstraDatabaseStatus.TERMINATED).ConfigureAwait(false);
             }
         }
-
-        return true;
     }
 
     /// <summary>

--- a/src/DataStax.AstraDB.DataApi/Admin/DatabaseAdminAstra.cs
+++ b/src/DataStax.AstraDB.DataApi/Admin/DatabaseAdminAstra.cs
@@ -161,34 +161,16 @@ namespace DataStax.AstraDB.DataApi.Admin
         /// </remarks>
         public void CreateKeyspace(string keyspace)
         {
-            CreateKeyspace(keyspace, false, null);
+            CreateKeyspace(keyspace, null);
         }
 
         /// <summary>
-        /// Synchronous version of <see cref="CreateKeyspaceAsync(string, BlockingCommandOptions)"/>
+        /// Synchronous version of <see cref="CreateKeyspaceAsync(string, CreateKeyspaceCommandOptions)"/>
         /// </summary>
-        /// <inheritdoc cref="CreateKeyspaceAsync(string, BlockingCommandOptions)"/>
-        public void CreateKeyspace(string keyspace, BlockingCommandOptions options)
+        /// <inheritdoc cref="CreateKeyspaceAsync(string, CreateKeyspaceCommandOptions)"/>
+        public void CreateKeyspace(string keyspace, CreateKeyspaceCommandOptions options)
         {
-            CreateKeyspace(keyspace, false, options);
-        }
-
-        /// <summary>
-        /// Synchronous version of <see cref="CreateKeyspaceAsync(string, bool)"/>
-        /// </summary>
-        /// <inheritdoc cref="CreateKeyspaceAsync(string, bool)"/>
-        public void CreateKeyspace(string keyspace, bool updateDBKeyspace)
-        {
-            CreateKeyspace(keyspace, updateDBKeyspace, null);
-        }
-
-        /// <summary>
-        /// Synchronous version of <see cref="CreateKeyspaceAsync(string, bool, BlockingCommandOptions)"/>
-        /// </summary>
-        /// <inheritdoc cref="CreateKeyspaceAsync(string, bool, BlockingCommandOptions)"/>
-        public void CreateKeyspace(string keyspace, bool updateDBKeyspace, BlockingCommandOptions options)
-        {
-            CreateKeyspaceAsync(keyspace, updateDBKeyspace, options, true).ResultSync();
+            CreateKeyspaceAsync(keyspace, options, true).ResultSync();
         }
 
         /// <summary>
@@ -206,7 +188,7 @@ namespace DataStax.AstraDB.DataApi.Admin
         /// </remarks>
         public Task CreateKeyspaceAsync(string keyspace)
         {
-            return CreateKeyspaceAsync(keyspace, false, null);
+            return CreateKeyspaceAsync(keyspace, null);
         }
 
         /// <inheritdoc cref="CreateKeyspaceAsync(string)"/>
@@ -217,41 +199,14 @@ namespace DataStax.AstraDB.DataApi.Admin
         /// await admin.CreateKeyspaceAsync("myKeyspace", options);
         /// </code>
         /// </example>
-        public Task CreateKeyspaceAsync(string keyspace, BlockingCommandOptions options)
+        public Task CreateKeyspaceAsync(string keyspace, CreateKeyspaceCommandOptions options)
         {
-            return CreateKeyspaceAsync(keyspace, false, options);
+            return CreateKeyspaceAsync(keyspace, options, false);
         }
 
-        /// <inheritdoc cref="CreateKeyspaceAsync(string)"/>
-        /// <param name="keyspace">The name of the keyspace to create.</param>
-        /// <param name="updateDBKeyspace">Whether to set this keyspace as the active keyspace for the associated Database.</param>
-        /// <example>
-        /// <code>
-        /// await admin.CreateKeyspaceAsync("myKeyspace", true);
-        /// </code>
-        /// </example>
-        public Task CreateKeyspaceAsync(string keyspace, bool updateDBKeyspace)
+        internal async Task CreateKeyspaceAsync(string keyspace, CreateKeyspaceCommandOptions options, bool runSynchronously)
         {
-            return CreateKeyspaceAsync(keyspace, updateDBKeyspace, null);
-        }
-
-        /// <inheritdoc cref="CreateKeyspaceAsync(string)"/>
-        /// <param name="keyspace">The name of the keyspace to create.</param>
-        /// <param name="updateDBKeyspace">Whether to set this keyspace as the active keyspace for the associated Database.</param>
-        /// <param name="options">Optional settings that influence request execution.</param>
-        /// <example>
-        /// <code>
-        /// await admin.CreateKeyspaceAsync("myKeyspace", true, options);
-        /// </code>
-        /// </example>
-        public Task CreateKeyspaceAsync(string keyspace, bool updateDBKeyspace, BlockingCommandOptions options)
-        {
-            return CreateKeyspaceAsync(keyspace, updateDBKeyspace, options, false);
-        }
-
-        internal async Task CreateKeyspaceAsync(string keyspace, bool updateDBKeyspace , BlockingCommandOptions options, bool runSynchronously)
-        {
-            options ??= new BlockingCommandOptions();
+            options ??= new CreateKeyspaceCommandOptions();
             options.IncludeKeyspaceInUrl = false;
             Guard.NotNullOrEmpty(keyspace, nameof(keyspace));
 
@@ -265,7 +220,7 @@ namespace DataStax.AstraDB.DataApi.Admin
 
             await command.RunAsyncRaw<Command.EmptyResult>(HttpMethod.Post, runSynchronously).ConfigureAwait(false);
 
-            if (updateDBKeyspace)
+            if (options.updateDBKeyspace)
             {
                 _database.UseKeyspace(keyspace);
             }

--- a/src/DataStax.AstraDB.DataApi/Admin/DatabaseAdminAstra.cs
+++ b/src/DataStax.AstraDB.DataApi/Admin/DatabaseAdminAstra.cs
@@ -155,9 +155,22 @@ namespace DataStax.AstraDB.DataApi.Admin
         /// Synchronous version of <see cref="CreateKeyspaceAsync(string)"/>
         /// </summary>
         /// <inheritdoc cref="CreateKeyspaceAsync(string)"/>
+        /// <remarks>
+        /// This method, by default, will wait for the operation to complete on the server side.
+        /// Use the options' waitForCompletion attribute to control this behaviour.
+        /// </remarks>
         public void CreateKeyspace(string keyspace)
         {
-            CreateKeyspace(keyspace, false, true, null);
+            CreateKeyspace(keyspace, false, null);
+        }
+
+        /// <summary>
+        /// Synchronous version of <see cref="CreateKeyspaceAsync(string, BlockingCommandOptions)"/>
+        /// </summary>
+        /// <inheritdoc cref="CreateKeyspaceAsync(string, BlockingCommandOptions)"/>
+        public void CreateKeyspace(string keyspace, BlockingCommandOptions options)
+        {
+            CreateKeyspace(keyspace, false, options);
         }
 
         /// <summary>
@@ -166,43 +179,16 @@ namespace DataStax.AstraDB.DataApi.Admin
         /// <inheritdoc cref="CreateKeyspaceAsync(string, bool)"/>
         public void CreateKeyspace(string keyspace, bool updateDBKeyspace)
         {
-            CreateKeyspace(keyspace, updateDBKeyspace, true, null);
+            CreateKeyspace(keyspace, updateDBKeyspace, null);
         }
 
         /// <summary>
-        /// Synchronous version of <see cref="CreateKeyspaceAsync(string, CommandOptions)"/>
+        /// Synchronous version of <see cref="CreateKeyspaceAsync(string, bool, BlockingCommandOptions)"/>
         /// </summary>
-        /// <inheritdoc cref="CreateKeyspaceAsync(string, CommandOptions)"/>
-        public void CreateKeyspace(string keyspace, CommandOptions options)
+        /// <inheritdoc cref="CreateKeyspaceAsync(string, bool, BlockingCommandOptions)"/>
+        public void CreateKeyspace(string keyspace, bool updateDBKeyspace, BlockingCommandOptions options)
         {
-            CreateKeyspace(keyspace, false, true, options);
-        }
-
-        /// <summary>
-        /// Synchronous version of <see cref="CreateKeyspaceAsync(string, bool, bool)"/>
-        /// </summary>
-        /// <inheritdoc cref="CreateKeyspaceAsync(string, bool, bool)"/>
-        public void CreateKeyspace(string keyspace, bool updateDBKeyspace, bool waitForCompletion)
-        {
-            CreateKeyspace(keyspace, updateDBKeyspace, waitForCompletion, null);
-        }
-
-        /// <summary>
-        /// Synchronous version of <see cref="CreateKeyspaceAsync(string, bool, CommandOptions)"/>
-        /// </summary>
-        /// <inheritdoc cref="CreateKeyspaceAsync(string, bool, CommandOptions)"/>
-        public void CreateKeyspace(string keyspace, bool updateDBKeyspace, CommandOptions options)
-        {
-            CreateKeyspace(keyspace, updateDBKeyspace, true, options);
-        }
-
-        /// <summary>
-        /// Synchronous version of <see cref="CreateKeyspaceAsync(string, bool, bool, CommandOptions)"/>
-        /// </summary>
-        /// <inheritdoc cref="CreateKeyspaceAsync(string, bool, bool, CommandOptions)"/>
-        public void CreateKeyspace(string keyspace, bool updateDBKeyspace, bool waitForCompletion, CommandOptions options)
-        {
-            CreateKeyspaceAsync(keyspace, updateDBKeyspace, waitForCompletion, options, true).ResultSync();
+            CreateKeyspaceAsync(keyspace, updateDBKeyspace, options, true).ResultSync();
         }
 
         /// <summary>
@@ -214,9 +200,26 @@ namespace DataStax.AstraDB.DataApi.Admin
         /// await admin.CreateKeyspaceAsync("myKeyspace");
         /// </code>
         /// </example>
+        /// <remarks>
+        /// This method, by default, will wait for the operation to complete on the server side.
+        /// Use the options' waitForCompletion attribute to control this behaviour.
+        /// </remarks>
         public Task CreateKeyspaceAsync(string keyspace)
         {
-            return CreateKeyspaceAsync(keyspace, false, true, null);
+            return CreateKeyspaceAsync(keyspace, false, null);
+        }
+
+        /// <inheritdoc cref="CreateKeyspaceAsync(string)"/>
+        /// <param name="keyspace">The name of the keyspace to create.</param>
+        /// <param name="options">Optional settings that influence request execution.</param>
+        /// <example>
+        /// <code>
+        /// await admin.CreateKeyspaceAsync("myKeyspace", options);
+        /// </code>
+        /// </example>
+        public Task CreateKeyspaceAsync(string keyspace, BlockingCommandOptions options)
+        {
+            return CreateKeyspaceAsync(keyspace, false, options);
         }
 
         /// <inheritdoc cref="CreateKeyspaceAsync(string)"/>
@@ -229,34 +232,7 @@ namespace DataStax.AstraDB.DataApi.Admin
         /// </example>
         public Task CreateKeyspaceAsync(string keyspace, bool updateDBKeyspace)
         {
-            return CreateKeyspaceAsync(keyspace, updateDBKeyspace, true, null);
-        }
-
-        /// <inheritdoc cref="CreateKeyspaceAsync(string)"/>
-        /// <param name="keyspace">The name of the keyspace to create.</param>
-        /// <param name="options">Optional settings that influence request execution.</param>
-        /// <example>
-        /// <code>
-        /// await admin.CreateKeyspaceAsync("myKeyspace", options);
-        /// </code>
-        /// </example>
-        public Task CreateKeyspaceAsync(string keyspace, CommandOptions options)
-        {
-            return CreateKeyspaceAsync(keyspace, false, true, options);
-        }
-
-        /// <inheritdoc cref="CreateKeyspaceAsync(string)"/>
-        /// <param name="keyspace">The name of the keyspace to create.</param>
-        /// <param name="updateDBKeyspace">Whether to set this keyspace as the active keyspace for the associated Database.</param>
-        /// <param name="waitForCompletion">Whether or not to wait for the keyspace to be created before returning.</param>
-        /// <example>
-        /// <code>
-        /// await admin.CreateKeyspaceAsync("myKeyspace", true, true);
-        /// </code>
-        /// </example>
-        public Task CreateKeyspaceAsync(string keyspace, bool updateDBKeyspace, bool waitForCompletion)
-        {
-            return CreateKeyspaceAsync(keyspace, updateDBKeyspace, waitForCompletion, null);
+            return CreateKeyspaceAsync(keyspace, updateDBKeyspace, null);
         }
 
         /// <inheritdoc cref="CreateKeyspaceAsync(string)"/>
@@ -268,29 +244,14 @@ namespace DataStax.AstraDB.DataApi.Admin
         /// await admin.CreateKeyspaceAsync("myKeyspace", true, options);
         /// </code>
         /// </example>
-        public Task CreateKeyspaceAsync(string keyspace, bool updateDBKeyspace, CommandOptions options)
+        public Task CreateKeyspaceAsync(string keyspace, bool updateDBKeyspace, BlockingCommandOptions options)
         {
-            return CreateKeyspaceAsync(keyspace, updateDBKeyspace, true, options);
+            return CreateKeyspaceAsync(keyspace, updateDBKeyspace, options, false);
         }
 
-        /// <inheritdoc cref="CreateKeyspaceAsync(string)"/>
-        /// <param name="keyspace">The name of the keyspace to create.</param>
-        /// <param name="updateDBKeyspace">Whether to set this keyspace as the active keyspace for the associated Database.</param>
-        /// <param name="waitForCompletion">Whether or not to wait for the keyspace to be created before returning.</param>
-        /// <param name="options">Optional settings that influence request execution.</param>
-        /// <example>
-        /// <code>
-        /// await admin.CreateKeyspaceAsync("myKeyspace", true, true, options);
-        /// </code>
-        /// </example>
-        public Task CreateKeyspaceAsync(string keyspace, bool updateDBKeyspace, bool waitForCompletion, CommandOptions options)
+        internal async Task CreateKeyspaceAsync(string keyspace, bool updateDBKeyspace , BlockingCommandOptions options, bool runSynchronously)
         {
-            return CreateKeyspaceAsync(keyspace, updateDBKeyspace, waitForCompletion, options, false);
-        }
-
-        internal async Task CreateKeyspaceAsync(string keyspace, bool updateDBKeyspace, bool waitForCompletion, CommandOptions options, bool runSynchronously)
-        {
-            options ??= new CommandOptions();
+            options ??= new BlockingCommandOptions();
             options.IncludeKeyspaceInUrl = false;
             Guard.NotNullOrEmpty(keyspace, nameof(keyspace));
 
@@ -309,7 +270,7 @@ namespace DataStax.AstraDB.DataApi.Admin
                 _database.UseKeyspace(keyspace);
             }
 
-            if (waitForCompletion)
+            if (options.waitForCompletion)
             {
                 try
                 {
@@ -326,51 +287,22 @@ namespace DataStax.AstraDB.DataApi.Admin
         /// Synchronous version of <see cref="DropKeyspaceAsync(string)"/>
         /// </summary>
         /// <inheritdoc cref="DropKeyspaceAsync(string)"/>
-        /// <example>
-        /// <code>
-        /// admin.DropKeyspace("myKeyspace");
-        /// </code>
-        /// </example>
+        /// <remarks>
+        /// This method, by default, will wait for the operation to complete on the server side.
+        /// Use the options' waitForCompletion attribute to control this behaviour.
+        /// </remarks>
         public void DropKeyspace(string keyspace)
         {
-            DropKeyspace(keyspace, true, null);
+            DropKeyspace(keyspace, null);
         }
 
         /// <summary>
-        /// Synchronous version of <see cref="DropKeyspaceAsync(string, bool)"/>
+        /// Synchronous version of <see cref="DropKeyspaceAsync(string, BlockingCommandOptions)"/>
         /// </summary>
-        /// <inheritdoc cref="DropKeyspaceAsync(string, bool)"/>
-        /// <example>
-        /// <code>
-        /// admin.DropKeyspace("myKeyspace", false);
-        /// </code>
-        /// </example>
-        public void DropKeyspace(string keyspace, bool waitForCompletion)
+        /// <inheritdoc cref="DropKeyspaceAsync(string, BlockingCommandOptions)"/>
+        public void DropKeyspace(string keyspace, BlockingCommandOptions options)
         {
-            DropKeyspace(keyspace, waitForCompletion, null);
-        }
-
-        /// <summary>
-        /// Synchronous version of <see cref="DropKeyspaceAsync(string, CommandOptions)"/>
-        /// </summary>
-        /// <inheritdoc cref="DropKeyspaceAsync(string, CommandOptions)"/>
-        /// <example>
-        /// <code>
-        /// admin.DropKeyspace("myKeyspace", options);
-        /// </code>
-        /// </example>
-        public void DropKeyspace(string keyspace, CommandOptions options)
-        {
-            DropKeyspace(keyspace, true, options);
-        }
-
-        /// <summary>
-        /// Synchronous version of <see cref="DropKeyspaceAsync(string, bool, CommandOptions)"/>
-        /// </summary>
-        /// <inheritdoc cref="DropKeyspaceAsync(string, bool, CommandOptions)"/>
-        public void DropKeyspace(string keyspace, bool waitForCompletion, CommandOptions options)
-        {
-            DropKeyspaceAsync(keyspace, waitForCompletion, options, true).ResultSync();
+            DropKeyspaceAsync(keyspace, options, true).ResultSync();
         }
 
         /// <summary>
@@ -383,60 +315,30 @@ namespace DataStax.AstraDB.DataApi.Admin
         /// </code>
         /// </example>
         /// <remarks>
-        /// This method will wait for the keyspace to be dropped before returning.
-        /// If you do not want to wait for the keyspace to be dropped, use the <see cref="DropKeyspaceAsync(string, bool, CommandOptions)"/> method.
+        /// This method, by default, will wait for the operation to complete on the server side.
+        /// Use the options' waitForCompletion attribute to control this behaviour.
         /// </remarks>
         public Task DropKeyspaceAsync(string keyspace)
         {
-            return DropKeyspaceAsync(keyspace, true, null);
+            return DropKeyspaceAsync(keyspace, null);
         }
 
         /// <inheritdoc cref="DropKeyspaceAsync(string)"/>
-        /// <param name="keyspace"></param>
-        /// <param name="waitForCompletion">Whether or not to wait for the keyspace to be dropped before returning.</param>
-        /// <example>
-        /// <code>
-        /// await admin.DropKeyspaceAsync("myKeyspace", false);
-        /// </code>
-        /// </example>
-        public Task DropKeyspaceAsync(string keyspace, bool waitForCompletion)
-        {
-            return DropKeyspaceAsync(keyspace, waitForCompletion, null);
-        }
-
-        /// <inheritdoc cref="DropKeyspaceAsync(string)"/>
-        /// <param name="keyspace"></param>
+        /// <param name="keyspace">The name of the keyspace to drop.</param>
         /// <param name="options">Optional settings that influence request execution.</param>
         /// <example>
         /// <code>
         /// await admin.DropKeyspaceAsync("myKeyspace", options);
         /// </code>
         /// </example>
-        /// <remarks>
-        /// This method will wait for the keyspace to be dropped before returning.
-        /// If you do not want to wait for the keyspace to be dropped, use the <see cref="DropKeyspaceAsync(string, bool, CommandOptions)"/> method.
-        /// </remarks>
-        public Task DropKeyspaceAsync(string keyspace, CommandOptions options)
+        public Task DropKeyspaceAsync(string keyspace, BlockingCommandOptions options)
         {
-            return DropKeyspaceAsync(keyspace, true, options, false);
+            return DropKeyspaceAsync(keyspace, options, false);
         }
 
-        /// <inheritdoc cref="DropKeyspaceAsync(string, CommandOptions)"/>
-        /// <param name="keyspace"></param>
-        /// <param name="waitForCompletion">Whether or not to wait for the keyspace to be dropped before returning.</param>
-        /// <param name="options"></param>
-        /// <example>
-        /// <code>
-        /// await admin.DropKeyspaceAsync("myKeyspace", true, options);
-        /// </code>
-        /// </example>
-        public Task DropKeyspaceAsync(string keyspace, bool waitForCompletion, CommandOptions options)
+        internal async Task DropKeyspaceAsync(string keyspace, BlockingCommandOptions options, bool runSynchronously)
         {
-            return DropKeyspaceAsync(keyspace, waitForCompletion, options, false);
-        }
-
-        internal async Task DropKeyspaceAsync(string keyspace, bool waitForCompletion, CommandOptions options, bool runSynchronously)
-        {
+            options ??= new BlockingCommandOptions();
             Guard.NotNullOrEmpty(keyspace, nameof(keyspace));
 
             var command = CreateCommandAdmin()
@@ -447,7 +349,7 @@ namespace DataStax.AstraDB.DataApi.Admin
             await command.RunAsyncRaw<Command.EmptyResult>(HttpMethod.Delete, runSynchronously)
                 .ConfigureAwait(false);
 
-            if (waitForCompletion)
+            if (options.waitForCompletion)
             {
                 try
                 {

--- a/src/DataStax.AstraDB.DataApi/Admin/DatabaseAdminDataAPI.cs
+++ b/src/DataStax.AstraDB.DataApi/Admin/DatabaseAdminDataAPI.cs
@@ -169,43 +169,25 @@ namespace DataStax.AstraDB.DataApi.Admin
         /// </remarks>
         public void CreateKeyspace(string keyspace)
         {
-            CreateKeyspace(keyspace, false, null, null);
+            CreateKeyspace(keyspace, null, null);
         }
 
         /// <summary>
-        /// Synchronous version of <see cref="CreateKeyspaceAsync(string, BlockingCommandOptions)"/>.
+        /// Synchronous version of <see cref="CreateKeyspaceAsync(string, CreateKeyspaceCommandOptions)"/>.
         /// </summary>
-        /// <inheritdoc cref="CreateKeyspaceAsync(string, BlockingCommandOptions)"/>
-        public void CreateKeyspace(string keyspace, BlockingCommandOptions options)
+        /// <inheritdoc cref="CreateKeyspaceAsync(string, CreateKeyspaceCommandOptions)"/>
+        public void CreateKeyspace(string keyspace, CreateKeyspaceCommandOptions options)
         {
-            CreateKeyspace(keyspace, false, options, null);
+            CreateKeyspace(keyspace, options, null);
         }
 
         /// <summary>
-        /// Synchronous version of <see cref="CreateKeyspaceAsync(string, bool)"/>.
+        /// Synchronous version of <see cref="CreateKeyspaceAsync(string, CreateKeyspaceCommandOptions, IDictionary{string,object})"/>.
         /// </summary>
-        /// <inheritdoc cref="CreateKeyspaceAsync(string, bool)"/>
-        public void CreateKeyspace(string keyspace, bool updateDBKeyspace)
+        /// <inheritdoc cref="CreateKeyspaceAsync(string, CreateKeyspaceCommandOptions, IDictionary{string,object})"/>
+        public void CreateKeyspace(string keyspace, CreateKeyspaceCommandOptions options, IDictionary<string,object> replicationOptions)
         {
-            CreateKeyspace(keyspace, updateDBKeyspace, null, null);
-        }
-
-        /// <summary>
-        /// Synchronous version of <see cref="CreateKeyspaceAsync(string, bool, BlockingCommandOptions)"/>.
-        /// </summary>
-        /// <inheritdoc cref="CreateKeyspaceAsync(string, bool, BlockingCommandOptions)"/>
-        public void CreateKeyspace(string keyspace, bool updateDBKeyspace, BlockingCommandOptions options)
-        {
-            CreateKeyspace(keyspace, updateDBKeyspace, options, null);
-        }
-
-        /// <summary>
-        /// Synchronous version of <see cref="CreateKeyspaceAsync(string, bool, BlockingCommandOptions, IDictionary{string,object})"/>.
-        /// </summary>
-        /// <inheritdoc cref="CreateKeyspaceAsync(string, bool, BlockingCommandOptions, IDictionary{string,object})"/>
-        public void CreateKeyspace(string keyspace, bool updateDBKeyspace, BlockingCommandOptions options, IDictionary<string,object> replicationOptions)
-        {
-            CreateKeyspaceAsync(keyspace, updateDBKeyspace, options, replicationOptions, true).ResultSync();
+            CreateKeyspaceAsync(keyspace, options, replicationOptions, true).ResultSync();
         }
 
         /// <summary>
@@ -223,7 +205,7 @@ namespace DataStax.AstraDB.DataApi.Admin
         /// </remarks>
         public Task CreateKeyspaceAsync(string keyspace)
         {
-            return CreateKeyspaceAsync(keyspace, false, null, null);
+            return CreateKeyspaceAsync(keyspace, null, null);
         }
 
         /// <inheritdoc cref="CreateKeyspaceAsync(string)"/>
@@ -234,57 +216,29 @@ namespace DataStax.AstraDB.DataApi.Admin
         /// await admin.CreateKeyspaceAsync("myKeyspace", options);
         /// </code>
         /// </example>
-        public Task CreateKeyspaceAsync(string keyspace, BlockingCommandOptions options)
+        public Task CreateKeyspaceAsync(string keyspace, CreateKeyspaceCommandOptions options)
         {
-            return CreateKeyspaceAsync(keyspace, false, options, null);
+            return CreateKeyspaceAsync(keyspace, options, null);
         }
 
         /// <inheritdoc cref="CreateKeyspaceAsync(string)"/>
         /// <param name="keyspace">The name of the keyspace to create.</param>
-        /// <param name="updateDBKeyspace">Whether to set this keyspace as the active keyspace for the associated Database.</param>
-        /// <example>
-        /// <code>
-        /// await admin.CreateKeyspaceAsync("myKeyspace", true);
-        /// </code>
-        /// </example>
-        public Task CreateKeyspaceAsync(string keyspace, bool updateDBKeyspace)
-        {
-            return CreateKeyspaceAsync(keyspace, updateDBKeyspace, null, null);
-        }
-
-        /// <inheritdoc cref="CreateKeyspaceAsync(string)"/>
-        /// <param name="keyspace">The name of the keyspace to create.</param>
-        /// <param name="updateDBKeyspace">Whether to set this keyspace as the active keyspace for the associated Database.</param>
-        /// <param name="options">Optional settings that influence request execution.</param>
-        /// <example>
-        /// <code>
-        /// await admin.CreateKeyspaceAsync("myKeyspace", true, options);
-        /// </code>
-        /// </example>
-        public Task CreateKeyspaceAsync(string keyspace, bool updateDBKeyspace, BlockingCommandOptions options)
-        {
-            return CreateKeyspaceAsync(keyspace, updateDBKeyspace, options, null);
-        }
-
-        /// <inheritdoc cref="CreateKeyspaceAsync(string)"/>
-        /// <param name="keyspace">The name of the keyspace to create.</param>
-        /// <param name="updateDBKeyspace">Whether to set this keyspace as the active keyspace for the associated Database.</param>
         /// <param name="options">Optional settings that influence request execution.</param>
         /// <param name="replicationOptions">Optional replication settings for the keyspace, e.g. {"class": "SimpleStrategy", "replication_factor": 3}.</param>
         /// <example>
         /// <code>
         /// var replicationSettings = new Dictionary&lt;string, object&gt; { ["class"] = "SimpleStrategy", ["replication_factor"] = 3 };
-        /// await admin.CreateKeyspaceAsync("myKeyspace", true, options, replicationSettings);
+        /// await admin.CreateKeyspaceAsync("myKeyspace", options, replicationSettings);
         /// </code>
         /// </example>
-        public Task CreateKeyspaceAsync(string keyspace, bool updateDBKeyspace, BlockingCommandOptions options, IDictionary<string,object> replicationOptions)
+        public Task CreateKeyspaceAsync(string keyspace, CreateKeyspaceCommandOptions options, IDictionary<string,object> replicationOptions)
         {
-            return CreateKeyspaceAsync(keyspace, updateDBKeyspace, options, replicationOptions, false);
+            return CreateKeyspaceAsync(keyspace, options, replicationOptions, false);
         }
 
-        internal async Task CreateKeyspaceAsync(string keyspace, bool updateDBKeyspace, BlockingCommandOptions options, IDictionary<string,object> replicationOptions, bool runSynchronously)
+        internal async Task CreateKeyspaceAsync(string keyspace, CreateKeyspaceCommandOptions options, IDictionary<string,object> replicationOptions, bool runSynchronously)
         {
-            options ??= new BlockingCommandOptions();
+            options ??= new CreateKeyspaceCommandOptions();
             options.IncludeKeyspaceInUrl = false;
             Guard.NotNullOrEmpty(keyspace, nameof(keyspace));
 
@@ -312,7 +266,7 @@ namespace DataStax.AstraDB.DataApi.Admin
                 .RunAsyncReturnStatus<object>(runSynchronously)
                 .ConfigureAwait(false);
 
-            if (updateDBKeyspace)
+            if (options.updateDBKeyspace)
             {
                 _database.UseKeyspace(keyspace);
             }

--- a/src/DataStax.AstraDB.DataApi/Admin/DatabaseAdminDataAPI.cs
+++ b/src/DataStax.AstraDB.DataApi/Admin/DatabaseAdminDataAPI.cs
@@ -163,9 +163,22 @@ namespace DataStax.AstraDB.DataApi.Admin
         /// Synchronous version of <see cref="CreateKeyspaceAsync(string)"/>.
         /// </summary>
         /// <inheritdoc cref="CreateKeyspaceAsync(string)"/>
+        /// <remarks>
+        /// This method, by default, will wait for the operation to complete on the server side.
+        /// Use the options' waitForCompletion attribute to control this behaviour.
+        /// </remarks>
         public void CreateKeyspace(string keyspace)
         {
-            CreateKeyspace(keyspace, false, true, null, null);
+            CreateKeyspace(keyspace, false, null, null);
+        }
+
+        /// <summary>
+        /// Synchronous version of <see cref="CreateKeyspaceAsync(string, BlockingCommandOptions)"/>.
+        /// </summary>
+        /// <inheritdoc cref="CreateKeyspaceAsync(string, BlockingCommandOptions)"/>
+        public void CreateKeyspace(string keyspace, BlockingCommandOptions options)
+        {
+            CreateKeyspace(keyspace, false, options, null);
         }
 
         /// <summary>
@@ -174,52 +187,25 @@ namespace DataStax.AstraDB.DataApi.Admin
         /// <inheritdoc cref="CreateKeyspaceAsync(string, bool)"/>
         public void CreateKeyspace(string keyspace, bool updateDBKeyspace)
         {
-            CreateKeyspace(keyspace, updateDBKeyspace, true, null, null);
+            CreateKeyspace(keyspace, updateDBKeyspace, null, null);
         }
 
         /// <summary>
-        /// Synchronous version of <see cref="CreateKeyspaceAsync(string, CommandOptions)"/>.
+        /// Synchronous version of <see cref="CreateKeyspaceAsync(string, bool, BlockingCommandOptions)"/>.
         /// </summary>
-        /// <inheritdoc cref="CreateKeyspaceAsync(string, CommandOptions)"/>
-        public void CreateKeyspace(string keyspace, CommandOptions options)
+        /// <inheritdoc cref="CreateKeyspaceAsync(string, bool, BlockingCommandOptions)"/>
+        public void CreateKeyspace(string keyspace, bool updateDBKeyspace, BlockingCommandOptions options)
         {
-            CreateKeyspace(keyspace, false, true, null, options);
+            CreateKeyspace(keyspace, updateDBKeyspace, options, null);
         }
 
         /// <summary>
-        /// Synchronous version of <see cref="CreateKeyspaceAsync(string, bool, bool)"/>.
+        /// Synchronous version of <see cref="CreateKeyspaceAsync(string, bool, BlockingCommandOptions, IDictionary{string,object})"/>.
         /// </summary>
-        /// <inheritdoc cref="CreateKeyspaceAsync(string, bool, bool)"/>
-        public void CreateKeyspace(string keyspace, bool updateDBKeyspace, bool waitForCompletion)
+        /// <inheritdoc cref="CreateKeyspaceAsync(string, bool, BlockingCommandOptions, IDictionary{string,object})"/>
+        public void CreateKeyspace(string keyspace, bool updateDBKeyspace, BlockingCommandOptions options, IDictionary<string,object> replicationOptions)
         {
-            CreateKeyspace(keyspace, updateDBKeyspace, waitForCompletion, null, null);
-        }
-
-        /// <summary>
-        /// Synchronous version of <see cref="CreateKeyspaceAsync(string, bool, CommandOptions)"/>.
-        /// </summary>
-        /// <inheritdoc cref="CreateKeyspaceAsync(string, bool, CommandOptions)"/>
-        public void CreateKeyspace(string keyspace, bool updateDBKeyspace, CommandOptions options)
-        {
-            CreateKeyspace(keyspace, updateDBKeyspace, true, null, options);
-        }
-
-        /// <summary>
-        /// Synchronous version of <see cref="CreateKeyspaceAsync(string, bool, bool, CommandOptions)"/>.
-        /// </summary>
-        /// <inheritdoc cref="CreateKeyspaceAsync(string, bool, bool, CommandOptions)"/>
-        public void CreateKeyspace(string keyspace, bool updateDBKeyspace, bool waitForCompletion, CommandOptions options)
-        {
-            CreateKeyspaceAsync(keyspace, updateDBKeyspace, waitForCompletion, null, options, true).ResultSync();
-        }
-
-        /// <summary>
-        /// Synchronous version of <see cref="CreateKeyspaceAsync(string, bool, bool, CommandOptions)"/>.
-        /// </summary>
-        /// <inheritdoc cref="CreateKeyspaceAsync(string, bool, bool, CommandOptions)"/>
-        public void CreateKeyspace(string keyspace, bool updateDBKeyspace, bool waitForCompletion, IDictionary<string,object> replicationOptions, CommandOptions options)
-        {
-            CreateKeyspaceAsync(keyspace, updateDBKeyspace, waitForCompletion, replicationOptions, options, true).ResultSync();
+            CreateKeyspaceAsync(keyspace, updateDBKeyspace, options, replicationOptions, true).ResultSync();
         }
 
         /// <summary>
@@ -231,68 +217,75 @@ namespace DataStax.AstraDB.DataApi.Admin
         /// await admin.CreateKeyspaceAsync("myKeyspace");
         /// </code>
         /// </example>
+        /// <remarks>
+        /// This method, by default, will wait for the operation to complete on the server side.
+        /// Use the options' waitForCompletion attribute to control this behaviour.
+        /// </remarks>
         public Task CreateKeyspaceAsync(string keyspace)
         {
-            return CreateKeyspaceAsync(keyspace, false, true, null, null);
+            return CreateKeyspaceAsync(keyspace, false, null, null);
+        }
+
+        /// <inheritdoc cref="CreateKeyspaceAsync(string)"/>
+        /// <param name="keyspace">The name of the keyspace to create.</param>
+        /// <param name="options">Optional settings that influence request execution.</param>
+        /// <example>
+        /// <code>
+        /// await admin.CreateKeyspaceAsync("myKeyspace", options);
+        /// </code>
+        /// </example>
+        public Task CreateKeyspaceAsync(string keyspace, BlockingCommandOptions options)
+        {
+            return CreateKeyspaceAsync(keyspace, false, options, null);
         }
 
         /// <inheritdoc cref="CreateKeyspaceAsync(string)"/>
         /// <param name="keyspace">The name of the keyspace to create.</param>
         /// <param name="updateDBKeyspace">Whether to set this keyspace as the active keyspace for the associated Database.</param>
+        /// <example>
+        /// <code>
+        /// await admin.CreateKeyspaceAsync("myKeyspace", true);
+        /// </code>
+        /// </example>
         public Task CreateKeyspaceAsync(string keyspace, bool updateDBKeyspace)
         {
-            return CreateKeyspaceAsync(keyspace, updateDBKeyspace, true, null, null);
-        }
-
-        /// <inheritdoc cref="CreateKeyspaceAsync(string)"/>
-        /// <param name="keyspace">The name of the keyspace to create.</param>
-        /// <param name="options">Optional settings that influence request execution.</param>
-        public Task CreateKeyspaceAsync(string keyspace, CommandOptions options)
-        {
-            return CreateKeyspaceAsync(keyspace, false, true, null, options);
-        }
-
-        /// <inheritdoc cref="CreateKeyspaceAsync(string)"/>
-        /// <param name="keyspace">The name of the keyspace to create.</param>
-        /// <param name="updateDBKeyspace">Whether to set this keyspace as the active keyspace for the associated Database.</param>
-        /// <param name="waitForCompletion">Whether to wait for the keyspace to be created before returning.</param>
-        public Task CreateKeyspaceAsync(string keyspace, bool updateDBKeyspace, bool waitForCompletion)
-        {
-            return CreateKeyspaceAsync(keyspace, updateDBKeyspace, waitForCompletion, null, null);
+            return CreateKeyspaceAsync(keyspace, updateDBKeyspace, null, null);
         }
 
         /// <inheritdoc cref="CreateKeyspaceAsync(string)"/>
         /// <param name="keyspace">The name of the keyspace to create.</param>
         /// <param name="updateDBKeyspace">Whether to set this keyspace as the active keyspace for the associated Database.</param>
         /// <param name="options">Optional settings that influence request execution.</param>
-        public Task CreateKeyspaceAsync(string keyspace, bool updateDBKeyspace, CommandOptions options)
+        /// <example>
+        /// <code>
+        /// await admin.CreateKeyspaceAsync("myKeyspace", true, options);
+        /// </code>
+        /// </example>
+        public Task CreateKeyspaceAsync(string keyspace, bool updateDBKeyspace, BlockingCommandOptions options)
         {
-            return CreateKeyspaceAsync(keyspace, updateDBKeyspace, true, null, options);
+            return CreateKeyspaceAsync(keyspace, updateDBKeyspace, options, null);
         }
 
         /// <inheritdoc cref="CreateKeyspaceAsync(string)"/>
         /// <param name="keyspace">The name of the keyspace to create.</param>
         /// <param name="updateDBKeyspace">Whether to set this keyspace as the active keyspace for the associated Database.</param>
-        /// <param name="waitForCompletion">Whether to wait for the keyspace to be created before returning.</param>
         /// <param name="options">Optional settings that influence request execution.</param>
-        public Task CreateKeyspaceAsync(string keyspace, bool updateDBKeyspace, bool waitForCompletion, CommandOptions options)
-        {
-            return CreateKeyspaceAsync(keyspace, updateDBKeyspace, waitForCompletion, null, options, false);
-        }
-
-        /// <inheritdoc cref="CreateKeyspaceAsync(string)"/>
-        /// <param name="keyspace">The name of the keyspace to create.</param>
-        /// <param name="updateDBKeyspace">Whether to set this keyspace as the active keyspace for the associated Database.</param>
-        /// <param name="waitForCompletion">Whether to wait for the keyspace to be created before returning.</param>
         /// <param name="replicationOptions">Optional replication settings for the keyspace, e.g. {"class": "SimpleStrategy", "replication_factor": 3}.</param>
-        /// <param name="options">Optional settings that influence request execution.</param>
-        public Task CreateKeyspaceAsync(string keyspace, bool updateDBKeyspace, bool waitForCompletion, IDictionary<string,object> replicationOptions, CommandOptions options)
+        /// <example>
+        /// <code>
+        /// var replicationSettings = new Dictionary&lt;string, object&gt; { ["class"] = "SimpleStrategy", ["replication_factor"] = 3 };
+        /// await admin.CreateKeyspaceAsync("myKeyspace", true, options, replicationSettings);
+        /// </code>
+        /// </example>
+        public Task CreateKeyspaceAsync(string keyspace, bool updateDBKeyspace, BlockingCommandOptions options, IDictionary<string,object> replicationOptions)
         {
-            return CreateKeyspaceAsync(keyspace, updateDBKeyspace, waitForCompletion, replicationOptions, options, false);
+            return CreateKeyspaceAsync(keyspace, updateDBKeyspace, options, replicationOptions, false);
         }
 
-        internal async Task CreateKeyspaceAsync(string keyspace, bool updateDBKeyspace, bool waitForCompletion, IDictionary<string,object> replicationOptions, CommandOptions options, bool runSynchronously)
+        internal async Task CreateKeyspaceAsync(string keyspace, bool updateDBKeyspace, BlockingCommandOptions options, IDictionary<string,object> replicationOptions, bool runSynchronously)
         {
+            options ??= new BlockingCommandOptions();
+            options.IncludeKeyspaceInUrl = false;
             Guard.NotNullOrEmpty(keyspace, nameof(keyspace));
 
             var createKeyspacePayload = new Dictionary<string, object>
@@ -324,7 +317,7 @@ namespace DataStax.AstraDB.DataApi.Admin
                 _database.UseKeyspace(keyspace);
             }
 
-            if (waitForCompletion)
+            if (options.waitForCompletion)
             {
                 try
                 {
@@ -341,36 +334,22 @@ namespace DataStax.AstraDB.DataApi.Admin
         /// Synchronous version of <see cref="DropKeyspaceAsync(string)"/>.
         /// </summary>
         /// <inheritdoc cref="DropKeyspaceAsync(string)"/>
+        /// <remarks>
+        /// This method, by default, will wait for the operation to complete on the server side.
+        /// Use the options' waitForCompletion attribute to control this behaviour.
+        /// </remarks>
         public void DropKeyspace(string keyspace)
         {
-            DropKeyspace(keyspace, false, null);
+            DropKeyspace(keyspace, null);
         }
 
         /// <summary>
-        /// Synchronous version of <see cref="DropKeyspaceAsync(string, bool)"/>.
+        /// Synchronous version of <see cref="DropKeyspaceAsync(string, BlockingCommandOptions)"/>.
         /// </summary>
-        /// <inheritdoc cref="DropKeyspaceAsync(string, bool)"/>
-        public void DropKeyspace(string keyspace, bool waitForCompletion)
+        /// <inheritdoc cref="DropKeyspaceAsync(string, BlockingCommandOptions)"/>
+        public void DropKeyspace(string keyspace, BlockingCommandOptions options)
         {
-            DropKeyspace(keyspace, waitForCompletion, null);
-        }
-
-        /// <summary>
-        /// Synchronous version of <see cref="DropKeyspaceAsync(string, CommandOptions)"/>.
-        /// </summary>
-        /// <inheritdoc cref="DropKeyspaceAsync(string, CommandOptions)"/>
-        public void DropKeyspace(string keyspace, CommandOptions options)
-        {
-            DropKeyspace(keyspace, false, options);
-        }
-
-        /// <summary>
-        /// Synchronous version of <see cref="DropKeyspaceAsync(string, bool, CommandOptions)"/>.
-        /// </summary>
-        /// <inheritdoc cref="DropKeyspaceAsync(string, bool, CommandOptions)"/>
-        public void DropKeyspace(string keyspace, bool waitForCompletion, CommandOptions options)
-        {
-            DropKeyspaceAsync(keyspace, waitForCompletion, options, true).ResultSync();
+            DropKeyspaceAsync(keyspace, options, true).ResultSync();
         }
 
         /// <summary>
@@ -382,38 +361,31 @@ namespace DataStax.AstraDB.DataApi.Admin
         /// await admin.DropKeyspaceAsync("myKeyspace");
         /// </code>
         /// </example>
+        /// <remarks>
+        /// This method, by default, will wait for the operation to complete on the server side.
+        /// Use the options' waitForCompletion attribute to control this behaviour.
+        /// </remarks>
         public Task DropKeyspaceAsync(string keyspace)
         {
-            return DropKeyspaceAsync(keyspace, false, null, false);
-        }
-
-        /// <inheritdoc cref="DropKeyspaceAsync(string)"/>
-        /// <param name="keyspace">The name of the keyspace to drop.</param>
-        /// <param name="waitForCompletion">Whether to wait for the keyspace to be dropped before returning.</param>
-        public Task DropKeyspaceAsync(string keyspace, bool waitForCompletion)
-        {
-            return DropKeyspaceAsync(keyspace, waitForCompletion, null, false);
+            return DropKeyspaceAsync(keyspace, null, false);
         }
 
         /// <inheritdoc cref="DropKeyspaceAsync(string)"/>
         /// <param name="keyspace">The name of the keyspace to drop.</param>
         /// <param name="options">Optional settings that influence request execution.</param>
-        public Task DropKeyspaceAsync(string keyspace, CommandOptions options)
+        /// <example>
+        /// <code>
+        /// await admin.DropKeyspaceAsync("myKeyspace", options);
+        /// </code>
+        /// </example>
+        public Task DropKeyspaceAsync(string keyspace, BlockingCommandOptions options)
         {
-            return DropKeyspaceAsync(keyspace, false, options, false);
+            return DropKeyspaceAsync(keyspace, options, false);
         }
 
-        /// <inheritdoc cref="DropKeyspaceAsync(string)"/>
-        /// <param name="keyspace">The name of the keyspace to drop.</param>
-        /// <param name="waitForCompletion">Whether to wait for the keyspace to be dropped before returning.</param>
-        /// <param name="options">Optional settings that influence request execution.</param>
-        public Task DropKeyspaceAsync(string keyspace, bool waitForCompletion, CommandOptions options)
+        internal async Task DropKeyspaceAsync(string keyspace, BlockingCommandOptions options, bool runSynchronously)
         {
-            return DropKeyspaceAsync(keyspace, waitForCompletion, options, false);
-        }
-
-        internal async Task DropKeyspaceAsync(string keyspace, bool waitForCompletion, CommandOptions options, bool runSynchronously)
-        {
+            options ??= new BlockingCommandOptions();
             Guard.NotNullOrEmpty(keyspace, nameof(keyspace));
 
             var command = CreateCommand()
@@ -431,7 +403,7 @@ namespace DataStax.AstraDB.DataApi.Admin
                 .RunAsyncReturnStatus<object>(runSynchronously)
                 .ConfigureAwait(false);
 
-            if (waitForCompletion)
+            if (options.waitForCompletion)
             {
                 try
                 {

--- a/src/DataStax.AstraDB.DataApi/Admin/IDatabaseAdmin.cs
+++ b/src/DataStax.AstraDB.DataApi/Admin/IDatabaseAdmin.cs
@@ -56,19 +56,11 @@ public interface IDatabaseAdmin
     /// <summary>Creates a new keyspace with the specified name.</summary>
     void CreateKeyspace(string keyspace);
     /// <summary>Creates a new keyspace with the specified name and command options.</summary>
-    void CreateKeyspace(string keyspace, BlockingCommandOptions options);
-    /// <summary>Creates a new keyspace, optionally updating the database's default keyspace.</summary>
-    void CreateKeyspace(string keyspace, bool updateDBKeyspace);
-    /// <summary>Creates a new keyspace, optionally updating the database's default keyspace, with command options.</summary>
-    void CreateKeyspace(string keyspace, bool updateDBKeyspace, BlockingCommandOptions options);
+    void CreateKeyspace(string keyspace, CreateKeyspaceCommandOptions options);
     /// <summary>Asynchronously creates a new keyspace with the specified name.</summary>
     Task CreateKeyspaceAsync(string keyspace);
     /// <summary>Asynchronously creates a new keyspace with the specified name and command options.</summary>
-    Task CreateKeyspaceAsync(string keyspace, BlockingCommandOptions options);
-    /// <summary>Asynchronously creates a new keyspace, optionally updating the database's default keyspace.</summary>
-    Task CreateKeyspaceAsync(string keyspace, bool updateDBKeyspace);
-    /// <summary>Asynchronously creates a new keyspace, optionally updating the database's default keyspace, with command options.</summary>
-    Task CreateKeyspaceAsync(string keyspace, bool updateDBKeyspace, BlockingCommandOptions options);
+    Task CreateKeyspaceAsync(string keyspace, CreateKeyspaceCommandOptions options);
     /// <summary>Drops the keyspace with the specified name.</summary>
     void DropKeyspace(string keyspace);
     /// <summary>Drops the keyspace with the specified name and command options.</summary>

--- a/src/DataStax.AstraDB.DataApi/Admin/IDatabaseAdmin.cs
+++ b/src/DataStax.AstraDB.DataApi/Admin/IDatabaseAdmin.cs
@@ -56,43 +56,27 @@ public interface IDatabaseAdmin
     /// <summary>Creates a new keyspace with the specified name.</summary>
     void CreateKeyspace(string keyspace);
     /// <summary>Creates a new keyspace with the specified name and command options.</summary>
-    void CreateKeyspace(string keyspace, CommandOptions options);
+    void CreateKeyspace(string keyspace, BlockingCommandOptions options);
     /// <summary>Creates a new keyspace, optionally updating the database's default keyspace.</summary>
     void CreateKeyspace(string keyspace, bool updateDBKeyspace);
     /// <summary>Creates a new keyspace, optionally updating the database's default keyspace, with command options.</summary>
-    void CreateKeyspace(string keyspace, bool updateDBKeyspace, CommandOptions options);
-    /// <summary>Creates a new keyspace, optionally updating the default keyspace and waiting for completion.</summary>
-    void CreateKeyspace(string keyspace, bool updateDBKeyspace, bool waitForCompletion);
-    /// <summary>Creates a new keyspace with all options specified.</summary>
-    void CreateKeyspace(string keyspace, bool updateDBKeyspace, bool waitForCompletion, CommandOptions options);
+    void CreateKeyspace(string keyspace, bool updateDBKeyspace, BlockingCommandOptions options);
     /// <summary>Asynchronously creates a new keyspace with the specified name.</summary>
     Task CreateKeyspaceAsync(string keyspace);
     /// <summary>Asynchronously creates a new keyspace with the specified name and command options.</summary>
-    Task CreateKeyspaceAsync(string keyspace, CommandOptions options);
+    Task CreateKeyspaceAsync(string keyspace, BlockingCommandOptions options);
     /// <summary>Asynchronously creates a new keyspace, optionally updating the database's default keyspace.</summary>
     Task CreateKeyspaceAsync(string keyspace, bool updateDBKeyspace);
     /// <summary>Asynchronously creates a new keyspace, optionally updating the database's default keyspace, with command options.</summary>
-    Task CreateKeyspaceAsync(string keyspace, bool updateDBKeyspace, CommandOptions options);
-    /// <summary>Asynchronously creates a new keyspace, optionally updating the default keyspace and waiting for completion.</summary>
-    Task CreateKeyspaceAsync(string keyspace, bool updateDBKeyspace, bool waitForCompletion);
-    /// <summary>Asynchronously creates a new keyspace with all options specified.</summary>
-    Task CreateKeyspaceAsync(string keyspace, bool updateDBKeyspace, bool waitForCompletion, CommandOptions options);
+    Task CreateKeyspaceAsync(string keyspace, bool updateDBKeyspace, BlockingCommandOptions options);
     /// <summary>Drops the keyspace with the specified name.</summary>
     void DropKeyspace(string keyspace);
     /// <summary>Drops the keyspace with the specified name and command options.</summary>
-    void DropKeyspace(string keyspace, CommandOptions options);
-    /// <summary>Drops the keyspace, optionally waiting for the operation to complete.</summary>
-    void DropKeyspace(string keyspace, bool waitForCompletion);
-    /// <summary>Drops the keyspace, optionally waiting for completion, with command options.</summary>
-    void DropKeyspace(string keyspace, bool waitForCompletion, CommandOptions options);
+    void DropKeyspace(string keyspace, BlockingCommandOptions options);
     /// <summary>Asynchronously drops the keyspace with the specified name.</summary>
     Task DropKeyspaceAsync(string keyspace);
     /// <summary>Asynchronously drops the keyspace with the specified name and command options.</summary>
-    Task DropKeyspaceAsync(string keyspace, CommandOptions options);
-    /// <summary>Asynchronously drops the keyspace, optionally waiting for the operation to complete.</summary>
-    Task DropKeyspaceAsync(string keyspace, bool waitForCompletion);
-    /// <summary>Asynchronously drops the keyspace, optionally waiting for completion, with command options.</summary>
-    Task DropKeyspaceAsync(string keyspace, bool waitForCompletion, CommandOptions options);
+    Task DropKeyspaceAsync(string keyspace, BlockingCommandOptions options);
     /// <summary>Returns <see langword="true"/> if the specified keyspace exists in the database.</summary>
     bool DoesKeyspaceExist(string keyspace);
     /// <summary>Asynchronously returns <see langword="true"/> if the specified keyspace exists in the database.</summary>

--- a/src/DataStax.AstraDB.DataApi/Core/BlockingCommandOptions.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/BlockingCommandOptions.cs
@@ -1,0 +1,28 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace DataStax.AstraDB.DataApi.Core;
+
+/// <summary>
+/// Options for long-running admin commands that may be launched in a blocking fashion.
+/// </summary>
+public class BlockingCommandOptions : CommandOptions
+{
+  /// <summary>
+  /// Whether to wait for the command to complete before returning.
+  /// </summary>
+  public bool waitForCompletion { get; set; } = true;
+}

--- a/src/DataStax.AstraDB.DataApi/Core/CreateKeyspaceCommandOptions.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/CreateKeyspaceCommandOptions.cs
@@ -1,0 +1,28 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace DataStax.AstraDB.DataApi.Core;
+
+/// <summary>
+/// Options specific to the database admin command to create a keyspace.
+/// </summary>
+public class CreateKeyspaceCommandOptions : BlockingCommandOptions
+{
+  /// <summary>
+  /// Whether to set the new keyspace as the active keyspace for the associated Database.
+  /// </summary>
+  public bool updateDBKeyspace { get; set; } = false;
+}

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdminTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdminTests.cs
@@ -555,8 +555,7 @@ public class AdminTests
 					Name = "theoretical_db_1",
 					CloudProvider = CloudProviderType.AWS,
 					Keyspace = "fedault_seykpace"
-				},
-				false
+				}
 			)
 		);
 		Assert.Contains("Value cannot be null or empty", ex1.Message);
@@ -567,8 +566,7 @@ public class AdminTests
 					CloudProvider = CloudProviderType.AWS,
 					Region = "the-region-",
 					Keyspace = "fedault_seykpace"
-				},
-				false
+				}
 			)
 		);
 		Assert.Contains("Value cannot be null or empty", ex2.Message);
@@ -579,8 +577,7 @@ public class AdminTests
 					Name = "theoretical_db_3",
 					Region = "the-region-",
 					Keyspace = "fedault_seykpace"
-				},
-				false
+				}
 			)
 		);
 		Assert.Contains("Value cannot be null", ex3.Message);
@@ -594,21 +591,29 @@ public class AdminTests
         1. Comment the attribute with the skip.
         2. Add a [Fact] attribute.
         3. Run the associated command from the terminal.
+
+		Also, make sure the DB creation/deletion parameters follow the env being tested:
+			DEV: GCP europe-west4
+			TEST: AWS us-east-1
+		For dropping, you will need to hardcode the proper database Guid in the test.
     */
 
 	// dotnet test --filter FullyQualifiedName=DataStax.AstraDB.DataApi.IntegrationTests.AdminTests.CreateDatabase
 	[Fact(Skip = AdminCollection.SkipMessage)]
-	public void CreateDatabase()
+	public void CreateDatabaseNonblocking()
 	{
 		var dbName = "test-db-create-x";
+		var creationOptions = new BlockingCommandOptions() {
+			waitForCompletion = false,
+		};
 		var admin = fixture.Client.GetAstraDatabasesAdmin().CreateDatabase(
 			new (){
 				Name = dbName,
-				CloudProvider = CloudProviderType.AWS,
-				Region = "us-east-2",
+				CloudProvider = CloudProviderType.GCP,
+				Region = "europe-west4",
 				Keyspace = "fedault_seykpace"
 			},
-			false
+			creationOptions
 		);
 
 		// todo: better test result here; for now we assume if no error, this was successful
@@ -616,15 +621,18 @@ public class AdminTests
 
 	// dotnet test --filter FullyQualifiedName=DataStax.AstraDB.DataApi.IntegrationTests.AdminTests.CreateDatabaseAsync
 	[Fact(Skip = AdminCollection.SkipMessage)]
-	public async Task CreateDatabaseAsync()
+	public async Task CreateDatabaseNonblockingAsync()
 	{
 		var dbName = "test-db-create-async-x";
 		var options = new DatabaseCreationOptions{
 			Name = dbName,
-			CloudProvider = CloudProviderType.AWS,
-			Region = "us-east-2"
+			CloudProvider = CloudProviderType.GCP,
+			Region = "europe-west4"
 		};
-		var admin = await fixture.Client.GetAstraDatabasesAdmin().CreateDatabaseAsync(options, false);
+		var creationOptions = new BlockingCommandOptions() {
+			waitForCompletion = false,
+		};
+		var admin = await fixture.Client.GetAstraDatabasesAdmin().CreateDatabaseAsync(options, creationOptions);
 
 		// todo: better test result here; for now we assume if no error, this was successful
 	}
@@ -636,11 +644,14 @@ public class AdminTests
 		var dbName = "test-db-create-blocking-x";
 		var options = new DatabaseCreationOptions{
 			Name = dbName,
-			CloudProvider = CloudProviderType.AWS,
-			Region = "us-east-2",
+			CloudProvider = CloudProviderType.GCP,
+			Region = "europe-west4",
 			Keyspace = "fedault_seykpace"
 		};
-		var admin = fixture.Client.GetAstraDatabasesAdmin().CreateDatabase(options, true);
+		var creationOptions = new BlockingCommandOptions() {
+			waitForCompletion = true,
+		};
+		var admin = fixture.Client.GetAstraDatabasesAdmin().CreateDatabase(options, creationOptions);
 
 		// todo: better test result here; for now we assume if no error, this was successful
 	}
@@ -650,13 +661,13 @@ public class AdminTests
 	public async Task CreateDatabaseBlockingAsync()
 	{
 		var dbName = "test-db-create-blocking-async-x";
+		// this one tests the "blocking by default" pattern:
 		var admin = await fixture.Client.GetAstraDatabasesAdmin().CreateDatabaseAsync(
 			new (){
 				Name = dbName,
-				CloudProvider = CloudProviderType.AWS,
-				Region = "us-east-1" // for TEST: use "us-east-1"; for DEV: "europe-west4"
-			},
-			true
+				CloudProvider = CloudProviderType.GCP,
+				Region = "europe-west4"
+			}
 		);
 
 		// verify by creating a keyspace (devops), listing it (devops) and listing the DB tables (data api)
@@ -669,42 +680,48 @@ public class AdminTests
 
 	// dotnet test --filter FullyQualifiedName=DataStax.AstraDB.DataApi.IntegrationTests.AdminTests.DropDatabase
 	[Fact(Skip = AdminCollection.SkipMessage)]
-	public void DropDatabase()
+	public void DropDatabaseNonblockingSync()
 	{
-		var dbGuid = "7683bb84-4604-49b4-b05f-69b695bba976"; // from a db created ad-hoc on astra's site
-		var dropped = fixture.Client.GetAstraDatabasesAdmin().DropDatabase(dbGuid, false);
-
-		Assert.True(dropped);
+		var waitingOptions = new BlockingCommandOptions
+		{
+			waitForCompletion = false,
+		};
+		var dbGuid = "06279ec0-c17c-498d-8bc4-b46cc04a2a71"; // tester must supply the Guid for a pre-created DB
+		fixture.Client.GetAstraDatabasesAdmin().DropDatabase(dbGuid, waitingOptions);
 	}
 
 	// dotnet test --filter FullyQualifiedName=DataStax.AstraDB.DataApi.IntegrationTests.AdminTests.DropDatabaseAsync
 	[Fact(Skip = AdminCollection.SkipMessage)]
-	public async Task DropDatabaseAsync()
+	public async Task DropDatabaseNonblockingAsync()
 	{
-		var dbGuid = "6a118896-bd69-4f24-90db-6229cd211c99"; // from a db created ad-hoc on astra's site
-		var dropped = await fixture.Client.GetAstraDatabasesAdmin().DropDatabaseAsync(dbGuid, false);
-
-		Assert.True(dropped);
+		var waitingOptions = new BlockingCommandOptions
+		{
+			waitForCompletion = false,
+		};
+		var dbGuid = "6a118896-bd69-4f24-90db-6229cd211c99"; // tester must supply the Guid for a pre-created DB
+		await fixture.Client.GetAstraDatabasesAdmin().DropDatabaseAsync(dbGuid, waitingOptions);
 	}
 
 	// dotnet test --filter FullyQualifiedName=DataStax.AstraDB.DataApi.IntegrationTests.AdminTests.DropDatabaseBlocking
 	[Fact(Skip = AdminCollection.SkipMessage)]
-	public void DropDatabaseBlocking()
+	public void DropDatabaseBlockingSync()
 	{
-		var dbGuid = "949c493b-0d08-41ca-b2e1-5a636c05f3ed"; // from a db created ad-hoc on astra's site
-		var dropped = fixture.Client.GetAstraDatabasesAdmin().DropDatabase(dbGuid, true);
-
-		Assert.True(dropped);
+		// this one tests the 'blocking by default' pattern:
+		var dbGuid = "4542468f-fcc8-4830-a8e6-b2acb65694be"; // tester must supply the Guid for a pre-created DB
+		fixture.Client.GetAstraDatabasesAdmin().DropDatabase(dbGuid);
 	}
 
 	// dotnet test --filter FullyQualifiedName=DataStax.AstraDB.DataApi.IntegrationTests.AdminTests.DropDatabaseBlockingAsync
 	[Fact(Skip = AdminCollection.SkipMessage)]
 	public async Task DropDatabaseBlockingAsync()
 	{
-		var dbGuid = "2b8bc268-511b-4b35-adfd-ef4f3063351b"; // from a db created ad-hoc on astra's site
-		var dropped = await fixture.Client.GetAstraDatabasesAdmin().DropDatabaseAsync(dbGuid, true);
-
-		Assert.True(dropped);
+		// this one explicitly requires the blocking call:
+		var waitingOptions = new BlockingCommandOptions
+		{
+			waitForCompletion = true,
+		};
+		var dbGuid = "37565911-f051-471a-9dc1-90a9eab76295"; // tester must supply the Guid for a pre-created DB
+		await fixture.Client.GetAstraDatabasesAdmin().DropDatabaseAsync(dbGuid, waitingOptions);
 	}
 
 	// dotnet test --filter FullyQualifiedName=DataStax.AstraDB.DataApi.IntegrationTests.AdminTests.DatabaseAdminAstra_CreateKeyspace_ExpectedError
@@ -725,7 +742,7 @@ public class AdminTests
 	public async Task DatabaseAdminAstra_CreateKeyspaceAsync()
 	{
 		var keyspaceName = "drop_this_keyspace_x";
-		var adminOptions = new CommandOptions
+		var adminOptions = new BlockingCommandOptions
 		{
 			Token = fixture.Client.ClientOptions.Token,
 		};
@@ -752,7 +769,7 @@ public class AdminTests
 		//		default_keyspace
 		*/
 		var keyspaceName = "drop_this_keyspace_x";
-		var adminOptions = new CommandOptions
+		var adminOptions = new BlockingCommandOptions
 		{
 			Token = fixture.Client.ClientOptions.Token,
 		};
@@ -805,7 +822,7 @@ public class AdminTests
 		//		default_keyspace
 		*/
 		var keyspaceName = "drop_this_keyspace_x";
-		var adminOptions = new CommandOptions
+		var adminOptions = new BlockingCommandOptions
 		{
 			Token = fixture.Client.ClientOptions.Token,
 		};
@@ -857,14 +874,14 @@ public class AdminTests
 	public async Task DatabaseAdminNonAstra_CreateKeyspaceAsync_WithOptions()
 	{
 		var keyspaceName = "throwaway_keyspace_with_options";
-		var adminOptions = new CommandOptions
+		var adminOptions = new BlockingCommandOptions
 		{
 			Token = fixture.Client.ClientOptions.Token,
 		};
 		var daa = new DatabaseAdminDataAPI(fixture.Database, fixture.Client, adminOptions);
 
 		var replicationOptions = new Dictionary<string, object> { ["class"] = "SimpleStrategy", ["replication_factor"] = 1 };
-		await daa.CreateKeyspaceAsync(keyspaceName, false, true, replicationOptions, adminOptions);
+		await daa.CreateKeyspaceAsync(keyspaceName, false, adminOptions, replicationOptions);
 
 		Assert.Contains(keyspaceName, daa.ListKeyspaces());
 	}
@@ -875,7 +892,7 @@ public class AdminTests
 	public async Task DatabaseAdminAstra_DropKeyspaceAsync()
 	{
 		var keyspaceName = "drop_this_keyspace_x";
-		var adminOptions = new CommandOptions
+		var adminOptions = new BlockingCommandOptions
 		{
 			Token = fixture.Client.ClientOptions.Token,
 		};
@@ -892,7 +909,7 @@ public class AdminTests
 	public async Task DatabaseAdminNonAstra_DropKeyspaceAsync()
 	{
 		var keyspaceName = "drop_this_keyspace_x";
-		var adminOptions = new CommandOptions
+		var adminOptions = new BlockingCommandOptions
 		{
 			Token = fixture.Client.ClientOptions.Token,
 		};

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdminTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdminTests.cs
@@ -737,18 +737,22 @@ public class AdminTests
 		Assert.Contains("Keyspace default_keyspace already exists", ex.Message);
 	}
 
-	// dotnet test --filter FullyQualifiedName=DataStax.AstraDB.DataApi.IntegrationTests.AdminTests.DatabaseAdminAstra_CreateKeyspaceAsync
+	// dotnet test --filter FullyQualifiedName=DataStax.AstraDB.DataApi.IntegrationTests.AdminTests.DatabaseAdminAstra_CreateKeyspaceAsync_ExplicitUpdateParameter
 	[Fact(Skip = AdminCollection.SkipMessage)]
-	public async Task DatabaseAdminAstra_CreateKeyspaceAsync()
+	public async Task DatabaseAdminAstra_CreateKeyspaceAsync_ExplicitUpdateParameter()
 	{
 		var keyspaceName = "drop_this_keyspace_x";
 		var adminOptions = new BlockingCommandOptions
 		{
 			Token = fixture.Client.ClientOptions.Token,
 		};
+		var ckOptions = new CreateKeyspaceCommandOptions
+		{
+			updateDBKeyspace = true,
+		};
 		var daa = new DatabaseAdminAstra(fixture.Database, fixture.Client, adminOptions);
 
-		await daa.CreateKeyspaceAsync(keyspaceName, adminOptions);
+		await daa.CreateKeyspaceAsync(keyspaceName, ckOptions);
 		Console.WriteLine($"DatabaseAdminAstra_CreateKeyspaceAsync > adminOptions.Keyspace: {adminOptions.Keyspace}");
 		Assert.Null(adminOptions.Keyspace);
 		// todo: better test result here; for now we assume if no error, this was successful
@@ -783,7 +787,7 @@ public class AdminTests
 		Assert.Equal("another_silly_puppet_keyspace", theDatabase.Keyspace);
 		var daa = new DatabaseAdminAstra(theDatabase, fixture.Client, adminOptions);
 
-		await daa.CreateKeyspaceAsync(keyspaceName, true, adminOptions);
+		await daa.CreateKeyspaceAsync(keyspaceName, new () {updateDBKeyspace = true});
 		Assert.Equal(keyspaceName, theDatabase.Keyspace);
 		// LCN myDB on keyspaceName
 		await theDatabase.ListCollectionNamesAsync();
@@ -826,6 +830,10 @@ public class AdminTests
 		{
 			Token = fixture.Client.ClientOptions.Token,
 		};
+		var ckOptions = new CreateKeyspaceCommandOptions
+		{
+			updateDBKeyspace = true,
+		};
 		// LCN fixDB on 'default_keyspace'
 		await fixture.Database.ListCollectionNamesAsync();
 
@@ -836,7 +844,7 @@ public class AdminTests
 		Assert.Equal("another_silly_puppet_keyspace", theDatabase.Keyspace);
 		var daa = new DatabaseAdminDataAPI(theDatabase, fixture.Client, adminOptions);
 
-		await daa.CreateKeyspaceAsync(keyspaceName, true, adminOptions);
+		await daa.CreateKeyspaceAsync(keyspaceName, ckOptions);
 		Assert.Equal(keyspaceName, theDatabase.Keyspace);
 		// LCN myDB on keyspaceName
 		await theDatabase.ListCollectionNamesAsync();
@@ -863,7 +871,7 @@ public class AdminTests
 		var swiftDatabase = fixture.Client.GetDatabase(fixture.DatabaseUrl,
 			new DatabaseCommandOptions() { Keyspace = "some_throwaway_keyspace_name" });
 		Assert.NotEqual(keyspaceName, swiftDatabase.Keyspace);
-		await swiftDatabase.GetAdmin().CreateKeyspaceAsync(keyspaceName, true, adminOptions);
+		await swiftDatabase.GetAdmin().CreateKeyspaceAsync(keyspaceName, ckOptions);
 		Assert.Equal(keyspaceName, swiftDatabase.Keyspace);
 
 	}
@@ -878,10 +886,14 @@ public class AdminTests
 		{
 			Token = fixture.Client.ClientOptions.Token,
 		};
+		var ckOptions = new CreateKeyspaceCommandOptions
+		{
+			Token = fixture.Client.ClientOptions.Token,
+		};
 		var daa = new DatabaseAdminDataAPI(fixture.Database, fixture.Client, adminOptions);
 
 		var replicationOptions = new Dictionary<string, object> { ["class"] = "SimpleStrategy", ["replication_factor"] = 1 };
-		await daa.CreateKeyspaceAsync(keyspaceName, false, adminOptions, replicationOptions);
+		await daa.CreateKeyspaceAsync(keyspaceName, ckOptions, replicationOptions);
 
 		Assert.Contains(keyspaceName, daa.ListKeyspaces());
 	}

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/DatabaseTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/DatabaseTests.cs
@@ -65,7 +65,11 @@ public class DatabaseTests
 
         try
         {
-            await admin.CreateKeyspaceAsync(keyspaceName, true, false);
+            var waitingOptions = new BlockingCommandOptions
+            {
+                waitForCompletion = false,
+            };
+            await admin.CreateKeyspaceAsync(keyspaceName, true, waitingOptions);
             var keyspaceExists = await admin.DoesKeyspaceExistAsync(keyspaceName);
             Assert.False(keyspaceExists, $"Keyspace '{keyspaceName}' should still be being created.");
 
@@ -81,13 +85,13 @@ public class DatabaseTests
 
             //Wait a minute before dropping to ensure db is in a stable state
             await Task.Delay(1 * 60 * 1000, TestContext.Current.CancellationToken);
-            await admin.DropKeyspaceAsync(keyspaceName, false);
+            await admin.DropKeyspaceAsync(keyspaceName, waitingOptions);
             keyspaceExists = await admin.DoesKeyspaceExistAsync(keyspaceName);
             Assert.True(keyspaceExists, $"Keyspace '{keyspaceName}' should still be being dropped.");
         }
         catch (Exception)
         {
-            await admin.DropKeyspaceAsync(keyspaceName, true);
+            await admin.DropKeyspaceAsync(keyspaceName);
         }
     }
 
@@ -100,10 +104,14 @@ public class DatabaseTests
 
         try
         {
-            await admin.CreateKeyspaceAsync(keyspaceName, true, true);
+            var waitingOptions = new BlockingCommandOptions
+            {
+                waitForCompletion = true,
+            };
+            await admin.CreateKeyspaceAsync(keyspaceName, true, waitingOptions);
             var keyspaceExists = await admin.DoesKeyspaceExistAsync(keyspaceName);
             Assert.True(keyspaceExists, $"Keyspace '{keyspaceName}' should exist after creation.");
-            await admin.DropKeyspaceAsync(keyspaceName, true);
+            await admin.DropKeyspaceAsync(keyspaceName, waitingOptions);
             keyspaceExists = await admin.DoesKeyspaceExistAsync(keyspaceName);
             Assert.False(keyspaceExists, $"Keyspace '{keyspaceName}' should not exist after drop.");
         }
@@ -111,7 +119,7 @@ public class DatabaseTests
         {
             try
             {
-                await admin.DropKeyspaceAsync(keyspaceName, true);
+                await admin.DropKeyspaceAsync(keyspaceName);
             }
             catch (Exception)
             {

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/DatabaseTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/DatabaseTests.cs
@@ -69,7 +69,12 @@ public class DatabaseTests
             {
                 waitForCompletion = false,
             };
-            await admin.CreateKeyspaceAsync(keyspaceName, true, waitingOptions);
+            var ckWaitingOptions = new CreateKeyspaceCommandOptions
+            {
+                waitForCompletion = false,
+                updateDBKeyspace = true,
+            };
+            await admin.CreateKeyspaceAsync(keyspaceName, ckWaitingOptions);
             var keyspaceExists = await admin.DoesKeyspaceExistAsync(keyspaceName);
             Assert.False(keyspaceExists, $"Keyspace '{keyspaceName}' should still be being created.");
 
@@ -108,7 +113,12 @@ public class DatabaseTests
             {
                 waitForCompletion = true,
             };
-            await admin.CreateKeyspaceAsync(keyspaceName, true, waitingOptions);
+            var ckWaitingOptions = new CreateKeyspaceCommandOptions
+            {
+                waitForCompletion = true,
+                updateDBKeyspace = true,
+            };
+            await admin.CreateKeyspaceAsync(keyspaceName, ckWaitingOptions);
             var keyspaceExists = await admin.DoesKeyspaceExistAsync(keyspaceName);
             Assert.True(keyspaceExists, $"Keyspace '{keyspaceName}' should exist after creation.");
             await admin.DropKeyspaceAsync(keyspaceName, waitingOptions);


### PR DESCRIPTION
Fixes #127 .
More specifically, this PR solves the issue of multiple/opaque bool params to `{Create/Drop} x {Database/Keyspace}`.

- a subclass `BlockingCommandOptions` of `CommandOptions`, used in those methods
- which contains a `waitForCompletion` boolean (defaulting to true)
- Moreover: reordered (the remaining) implementations for uniformity
- Moreover: **breaking change** brought the "replication options" at the end of the signature for HCD's CreateKeyspace for uniformity
- Moreover: rephrase/rearrange xmldocs (use "inheritfrom", improve param description, presence/absence of code examples and such)
- Moreover: `DropDatabase` is not a `bool` anymore, rather a void, as its semantics would (also DropKeyspace and other clients work like that) **(slight) breaking change**
-  (Some tests renamed and slightly reformulated, also some comments therein)


[the following part outdated, see further posts]
~Now I did _not_ subsume `updateDbKeyspace` into these options... yet. I am not 100% sure this should be done at all:~

1. ~it's only one boolean (still 'opaque', but just one)~
2. ~Its meaning is not really that of "an option that controls request execution" to be strict (like the rest of BlockingCommandOptions is)~
3. ~keeping it top-level saves the quick, easy HCD one-liner "create keyspace and have the DB set to use it". Otherwise it would get a tad more verbose.~

~@toptobes any opinion?~