### PR TITLE
Refine the vectorize annotations to cover all cases (+ extensive tests/examples)

### DIFF
--- a/src/DataStax.AstraDB.DataApi/Core/CollectionDefinition.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/CollectionDefinition.cs
@@ -113,11 +113,14 @@ public class CollectionDefinition
             {
                 definition.Vector = new VectorOptions();
             }
-            if (vectorAttribute.Dimension != -1)
+            if (vectorAttribute.Dimension.HasValue && vectorAttribute.Dimension.Value != -1)
             {
-                definition.Vector.Dimension = vectorAttribute.Dimension;
+                definition.Vector.Dimension = vectorAttribute.Dimension.Value;
             }
-            definition.Vector.Metric = vectorAttribute.Metric;
+            if (vectorAttribute.Metric.HasValue)
+            {
+                definition.Vector.Metric = vectorAttribute.Metric.Value;
+            }
             if (!string.IsNullOrEmpty(vectorAttribute.SourceModel))
             {
                 definition.Vector.SourceModel = vectorAttribute.SourceModel;
@@ -131,11 +134,14 @@ public class CollectionDefinition
             {
                 definition.Vector = new VectorOptions();
             }
-            if (vectorizeAttribute.Dimension != -1)
+            if (vectorizeAttribute.Dimension.HasValue && vectorizeAttribute.Dimension.Value != -1)
             {
-                definition.Vector.Dimension = vectorizeAttribute.Dimension;
+                definition.Vector.Dimension = vectorizeAttribute.Dimension.Value;
             }
-            definition.Vector.Metric = vectorizeAttribute.Metric;
+            if (vectorAttribute.Metric.HasValue)
+            {
+                definition.Vector.Metric = vectorizeAttribute.Metric.Value;
+            }
             if (!string.IsNullOrEmpty(vectorizeAttribute.Provider))
             {
                 definition.Vector.Service = new VectorServiceOptions()

--- a/src/DataStax.AstraDB.DataApi/Core/CollectionDefinition.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/CollectionDefinition.cs
@@ -138,7 +138,7 @@ public class CollectionDefinition
             {
                 definition.Vector.Dimension = vectorizeAttribute.Dimension.Value;
             }
-            if (vectorAttribute.Metric.HasValue)
+            if (vectorizeAttribute.Metric.HasValue)
             {
                 definition.Vector.Metric = vectorizeAttribute.Metric.Value;
             }

--- a/src/DataStax.AstraDB.DataApi/Core/CollectionVectorAttribute.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/CollectionVectorAttribute.cs
@@ -41,4 +41,36 @@ public class CollectionVectorAttribute : Attribute
     /// </summary>
     public CollectionVectorAttribute() { }
 
+    /// <summary>
+    /// Initializes a new instance with the specified dimension.
+    /// </summary>
+    /// <param name="dimension">The number of dimensions for the vector.</param>
+    public CollectionVectorAttribute(int dimension)
+    {
+        Dimension = dimension;
+    }
+
+    /// <summary>
+    /// Initializes a new instance with the specified dimension and metric.
+    /// </summary>
+    /// <param name="dimension">The number of dimensions for the vector.</param>
+    /// <param name="metric">The similarity metric to use for vector comparisons.</param>
+    public CollectionVectorAttribute(int dimension, SimilarityMetric metric)
+    {
+        Dimension = dimension;
+        Metric = metric;
+    }
+
+    /// <summary>
+    /// Initializes a new instance with the specified dimension, metric, and source model.
+    /// </summary>
+    /// <param name="dimension">The number of dimensions for the vector.</param>
+    /// <param name="metric">The similarity metric to use for vector comparisons.</param>
+    /// <param name="sourceModel">The source model for embeddings optimization.</param>
+    public CollectionVectorAttribute(int dimension, SimilarityMetric metric, string sourceModel)
+    {
+        Dimension = dimension;
+        Metric = metric;
+        SourceModel = sourceModel;
+    }
 }

--- a/src/DataStax.AstraDB.DataApi/Core/CollectionVectorAttribute.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/CollectionVectorAttribute.cs
@@ -28,7 +28,7 @@ public class CollectionVectorAttribute : Attribute
     public int? Dimension { get; set; } = null;
 
     /// <summary>The similarity metric to use for vector comparisons.</summary>
-    public SimilarityMetric Metric { get; set; } = SimilarityMetric.Cosine;
+    public SimilarityMetric? Metric { get; set; }
 
     /// <summary>
     /// Configures the index with the fastest settings for a given source of embeddings vectors.

--- a/src/DataStax.AstraDB.DataApi/Core/CollectionVectorAttribute.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/CollectionVectorAttribute.cs
@@ -42,35 +42,32 @@ public class CollectionVectorAttribute : Attribute
     public CollectionVectorAttribute() { }
 
     /// <summary>
-    /// Initializes a new instance with the specified dimension.
+    /// Initializes a new instance, optionally specifying various settings.
     /// </summary>
-    /// <param name="dimension">The number of dimensions for the vector.</param>
-    public CollectionVectorAttribute(int dimension)
+    /// <param name="dimension">Optional. The number of dimensions for the vector.</param>
+    /// <param name="sourceModel">Optional. The source model for embeddings optimization.</param>
+    public CollectionVectorAttribute(
+        int dimension = -1,
+        string sourceModel = null)
     {
-        Dimension = dimension;
-    }
-
-    /// <summary>
-    /// Initializes a new instance with the specified dimension and metric.
-    /// </summary>
-    /// <param name="dimension">The number of dimensions for the vector.</param>
-    /// <param name="metric">The similarity metric to use for vector comparisons.</param>
-    public CollectionVectorAttribute(int dimension, SimilarityMetric metric)
-    {
-        Dimension = dimension;
-        Metric = metric;
-    }
-
-    /// <summary>
-    /// Initializes a new instance with the specified dimension, metric, and source model.
-    /// </summary>
-    /// <param name="dimension">The number of dimensions for the vector.</param>
-    /// <param name="metric">The similarity metric to use for vector comparisons.</param>
-    /// <param name="sourceModel">The source model for embeddings optimization.</param>
-    public CollectionVectorAttribute(int dimension, SimilarityMetric metric, string sourceModel)
-    {
-        Dimension = dimension;
-        Metric = metric;
+        Dimension = dimension == -1 ? null : dimension;
         SourceModel = sourceModel;
     }
+
+    /// <summary>
+    /// Initializes a new instance with the specified metric and optionally other settings.
+    /// </summary>
+    /// <param name="metric">The similarity metric to use for vector comparisons.</param>
+    /// <param name="dimension">Optional. The number of dimensions for the vector.</param>
+    /// <param name="sourceModel">Optional. The source model for embeddings optimization.</param>
+    public CollectionVectorAttribute(
+        SimilarityMetric metric,
+        int dimension = -1,
+        string sourceModel = null)
+    {
+        Metric = metric;
+        Dimension = dimension == -1 ? null : dimension;
+        SourceModel = sourceModel;
+    }
+
 }

--- a/src/DataStax.AstraDB.DataApi/Core/CollectionVectorizeAttribute.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/CollectionVectorizeAttribute.cs
@@ -33,4 +33,156 @@ public class CollectionVectorizeAttribute : BaseVectorizeAttribute
     /// </summary>
     public CollectionVectorizeAttribute() { }
 
+    /// <summary>
+    /// Initializes a new instance with the specified provider and model name.
+    /// </summary>
+    /// <param name="provider">The name of the embedding service provider.</param>
+    /// <param name="modelName">The model name to use for embedding generation.</param>
+    public CollectionVectorizeAttribute(string provider, string modelName)
+    {
+        Provider = provider;
+        ModelName = modelName;
+    }
+
+    /// <summary>
+    /// Initializes a new instance with the specified provider, model name, and dimension.
+    /// </summary>
+    /// <param name="provider">The name of the embedding service provider.</param>
+    /// <param name="modelName">The model name to use for embedding generation.</param>
+    /// <param name="dimension">The number of dimensions for the generated vector.</param>
+    public CollectionVectorizeAttribute(string provider, string modelName, int dimension)
+    {
+        Provider = provider;
+        ModelName = modelName;
+        Dimension = dimension;
+    }
+
+    /// <summary>
+    /// Initializes a new instance with the specified provider, model name, dimension, and metric.
+    /// </summary>
+    /// <param name="provider">The name of the embedding service provider.</param>
+    /// <param name="modelName">The model name to use for embedding generation.</param>
+    /// <param name="dimension">The number of dimensions for the generated vector.</param>
+    /// <param name="metric">The similarity metric to use for vector comparisons.</param>
+    public CollectionVectorizeAttribute(string provider, string modelName, int dimension, SimilarityMetric metric)
+    {
+        Provider = provider;
+        ModelName = modelName;
+        Dimension = dimension;
+        Metric = metric;
+    }
+
+    /// <summary>
+    /// Initializes a new instance with the specified provider, model name, dimension, metric, and authentication.
+    /// </summary>
+    /// <param name="provider">The name of the embedding service provider.</param>
+    /// <param name="modelName">The model name to use for embedding generation.</param>
+    /// <param name="dimension">The number of dimensions for the generated vector.</param>
+    /// <param name="metric">The similarity metric to use for vector comparisons.</param>
+    /// <param name="authenticationPairs">Key-value pairs for authenticating with the embedding service.</param>
+    public CollectionVectorizeAttribute(string provider, string modelName, int dimension, SimilarityMetric metric, string[] authenticationPairs)
+    {
+        Provider = provider;
+        ModelName = modelName;
+        Dimension = dimension;
+        Metric = metric;
+        AuthenticationPairs = authenticationPairs;
+    }
+
+    /// <summary>
+    /// Initializes a new instance with the specified provider, model name, dimension, metric, authentication, and parameters.
+    /// </summary>
+    /// <param name="provider">The name of the embedding service provider.</param>
+    /// <param name="modelName">The model name to use for embedding generation.</param>
+    /// <param name="dimension">The number of dimensions for the generated vector.</param>
+    /// <param name="metric">The similarity metric to use for vector comparisons.</param>
+    /// <param name="authenticationPairs">Key-value pairs for authenticating with the embedding service.</param>
+    /// <param name="parameterPairs">Additional key-value parameter pairs for the embedding service.</param>
+    public CollectionVectorizeAttribute(string provider, string modelName, int dimension, SimilarityMetric metric, string[] authenticationPairs, object[] parameterPairs)
+    {
+        Provider = provider;
+        ModelName = modelName;
+        Dimension = dimension;
+        Metric = metric;
+        AuthenticationPairs = authenticationPairs;
+        ParameterPairs = parameterPairs;
+    }
+
+    /// <summary>
+    /// Initializes a new instance with the specified provider, model name, dimension, and authentication.
+    /// </summary>
+    /// <param name="provider">The name of the embedding service provider.</param>
+    /// <param name="modelName">The model name to use for embedding generation.</param>
+    /// <param name="dimension">The number of dimensions for the generated vector.</param>
+    /// <param name="authenticationPairs">Key-value pairs for authenticating with the embedding service.</param>
+    public CollectionVectorizeAttribute(string provider, string modelName, int dimension, string[] authenticationPairs)
+    {
+        Provider = provider;
+        ModelName = modelName;
+        Dimension = dimension;
+        AuthenticationPairs = authenticationPairs;
+    }
+
+    /// <summary>
+    /// Initializes a new instance with the specified provider, model name, dimension, authentication, and parameters.
+    /// </summary>
+    /// <param name="provider">The name of the embedding service provider.</param>
+    /// <param name="modelName">The model name to use for embedding generation.</param>
+    /// <param name="dimension">The number of dimensions for the generated vector.</param>
+    /// <param name="authenticationPairs">Key-value pairs for authenticating with the embedding service.</param>
+    /// <param name="parameterPairs">Additional key-value parameter pairs for the embedding service.</param>
+    public CollectionVectorizeAttribute(string provider, string modelName, int dimension, string[] authenticationPairs, object[] parameterPairs)
+    {
+        Provider = provider;
+        ModelName = modelName;
+        Dimension = dimension;
+        AuthenticationPairs = authenticationPairs;
+        ParameterPairs = parameterPairs;
+    }
+
+    /// <summary>
+    /// Initializes a new instance with the specified provider, model name, and metric.
+    /// </summary>
+    /// <param name="provider">The name of the embedding service provider.</param>
+    /// <param name="modelName">The model name to use for embedding generation.</param>
+    /// <param name="metric">The similarity metric to use for vector comparisons.</param>
+    public CollectionVectorizeAttribute(string provider, string modelName, SimilarityMetric metric)
+    {
+        Provider = provider;
+        ModelName = modelName;
+        Metric = metric;
+    }
+
+    /// <summary>
+    /// Initializes a new instance with the specified provider, model name, metric, and authentication.
+    /// </summary>
+    /// <param name="provider">The name of the embedding service provider.</param>
+    /// <param name="modelName">The model name to use for embedding generation.</param>
+    /// <param name="metric">The similarity metric to use for vector comparisons.</param>
+    /// <param name="authenticationPairs">Key-value pairs for authenticating with the embedding service.</param>
+    public CollectionVectorizeAttribute(string provider, string modelName, SimilarityMetric metric, string[] authenticationPairs)
+    {
+        Provider = provider;
+        ModelName = modelName;
+        Metric = metric;
+        AuthenticationPairs = authenticationPairs;
+    }
+
+    /// <summary>
+    /// Initializes a new instance with the specified provider, model name, metric, authentication, and parameters.
+    /// </summary>
+    /// <param name="provider">The name of the embedding service provider.</param>
+    /// <param name="modelName">The model name to use for embedding generation.</param>
+    /// <param name="metric">The similarity metric to use for vector comparisons.</param>
+    /// <param name="authenticationPairs">Key-value pairs for authenticating with the embedding service.</param>
+    /// <param name="parameterPairs">Additional key-value parameter pairs for the embedding service.</param>
+    public CollectionVectorizeAttribute(string provider, string modelName, SimilarityMetric metric, string[] authenticationPairs, object[] parameterPairs)
+    {
+        Provider = provider;
+        ModelName = modelName;
+        Metric = metric;
+        AuthenticationPairs = authenticationPairs;
+        ParameterPairs = parameterPairs;
+    }
+
 }

--- a/src/DataStax.AstraDB.DataApi/Core/CollectionVectorizeAttribute.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/CollectionVectorizeAttribute.cs
@@ -34,63 +34,29 @@ public class CollectionVectorizeAttribute : BaseVectorizeAttribute
     public CollectionVectorizeAttribute() { }
 
     /// <summary>
-    /// Initializes a new instance with the specified provider and model name.
-    /// </summary>
-    /// <param name="provider">The name of the embedding service provider.</param>
-    /// <param name="modelName">The model name to use for embedding generation.</param>
-    public CollectionVectorizeAttribute(string provider, string modelName)
-    {
-        Provider = provider;
-        ModelName = modelName;
-    }
-
-    /// <summary>
-    /// Initializes a new instance with the specified provider, model name, and dimension.
+    /// Initializes a new instance with the specified provider and model name and optionally other settings.
     /// </summary>
     /// <param name="provider">The name of the embedding service provider.</param>
     /// <param name="modelName">The model name to use for embedding generation.</param>
     /// <param name="dimension">The number of dimensions for the generated vector.</param>
-    public CollectionVectorizeAttribute(string provider, string modelName, int dimension)
-    {
-        Provider = provider;
-        ModelName = modelName;
-        Dimension = dimension;
-    }
-
-    /// <summary>
-    /// Initializes a new instance with the specified provider, model name, dimension, and metric.
-    /// </summary>
-    /// <param name="provider">The name of the embedding service provider.</param>
-    /// <param name="modelName">The model name to use for embedding generation.</param>
-    /// <param name="dimension">The number of dimensions for the generated vector.</param>
-    /// <param name="metric">The similarity metric to use for vector comparisons.</param>
-    public CollectionVectorizeAttribute(string provider, string modelName, int dimension, SimilarityMetric metric)
-    {
-        Provider = provider;
-        ModelName = modelName;
-        Dimension = dimension;
-        Metric = metric;
-    }
-
-    /// <summary>
-    /// Initializes a new instance with the specified provider, model name, dimension, metric, and authentication.
-    /// </summary>
-    /// <param name="provider">The name of the embedding service provider.</param>
-    /// <param name="modelName">The model name to use for embedding generation.</param>
-    /// <param name="dimension">The number of dimensions for the generated vector.</param>
-    /// <param name="metric">The similarity metric to use for vector comparisons.</param>
     /// <param name="authenticationPairs">Key-value pairs for authenticating with the embedding service.</param>
-    public CollectionVectorizeAttribute(string provider, string modelName, int dimension, SimilarityMetric metric, string[] authenticationPairs)
+    /// <param name="parameterPairs">Additional key-value parameter pairs for the embedding service.</param>
+    public CollectionVectorizeAttribute(
+        string provider,
+        string modelName,
+        int dimension = -1,
+        string[] authenticationPairs = null,
+        object[] parameterPairs = null)
     {
         Provider = provider;
         ModelName = modelName;
-        Dimension = dimension;
-        Metric = metric;
-        AuthenticationPairs = authenticationPairs;
+        Dimension = dimension == -1 ? null : dimension;
+        AuthenticationPairs = authenticationPairs ?? Array.Empty<string>();
+        ParameterPairs = parameterPairs ?? Array.Empty<object>();
     }
 
     /// <summary>
-    /// Initializes a new instance with the specified provider, model name, dimension, metric, authentication, and parameters.
+    /// Initializes a new instance with the specified provider and model name and optionally other settings.
     /// </summary>
     /// <param name="provider">The name of the embedding service provider.</param>
     /// <param name="modelName">The model name to use for embedding generation.</param>
@@ -98,91 +64,20 @@ public class CollectionVectorizeAttribute : BaseVectorizeAttribute
     /// <param name="metric">The similarity metric to use for vector comparisons.</param>
     /// <param name="authenticationPairs">Key-value pairs for authenticating with the embedding service.</param>
     /// <param name="parameterPairs">Additional key-value parameter pairs for the embedding service.</param>
-    public CollectionVectorizeAttribute(string provider, string modelName, int dimension, SimilarityMetric metric, string[] authenticationPairs, object[] parameterPairs)
-    {
-        Provider = provider;
-        ModelName = modelName;
-        Dimension = dimension;
-        Metric = metric;
-        AuthenticationPairs = authenticationPairs;
-        ParameterPairs = parameterPairs;
-    }
-
-    /// <summary>
-    /// Initializes a new instance with the specified provider, model name, dimension, and authentication.
-    /// </summary>
-    /// <param name="provider">The name of the embedding service provider.</param>
-    /// <param name="modelName">The model name to use for embedding generation.</param>
-    /// <param name="dimension">The number of dimensions for the generated vector.</param>
-    /// <param name="authenticationPairs">Key-value pairs for authenticating with the embedding service.</param>
-    public CollectionVectorizeAttribute(string provider, string modelName, int dimension, string[] authenticationPairs)
-    {
-        Provider = provider;
-        ModelName = modelName;
-        Dimension = dimension;
-        AuthenticationPairs = authenticationPairs;
-    }
-
-    /// <summary>
-    /// Initializes a new instance with the specified provider, model name, dimension, authentication, and parameters.
-    /// </summary>
-    /// <param name="provider">The name of the embedding service provider.</param>
-    /// <param name="modelName">The model name to use for embedding generation.</param>
-    /// <param name="dimension">The number of dimensions for the generated vector.</param>
-    /// <param name="authenticationPairs">Key-value pairs for authenticating with the embedding service.</param>
-    /// <param name="parameterPairs">Additional key-value parameter pairs for the embedding service.</param>
-    public CollectionVectorizeAttribute(string provider, string modelName, int dimension, string[] authenticationPairs, object[] parameterPairs)
-    {
-        Provider = provider;
-        ModelName = modelName;
-        Dimension = dimension;
-        AuthenticationPairs = authenticationPairs;
-        ParameterPairs = parameterPairs;
-    }
-
-    /// <summary>
-    /// Initializes a new instance with the specified provider, model name, and metric.
-    /// </summary>
-    /// <param name="provider">The name of the embedding service provider.</param>
-    /// <param name="modelName">The model name to use for embedding generation.</param>
-    /// <param name="metric">The similarity metric to use for vector comparisons.</param>
-    public CollectionVectorizeAttribute(string provider, string modelName, SimilarityMetric metric)
+    public CollectionVectorizeAttribute(
+        string provider,
+        string modelName,
+        SimilarityMetric metric,
+        int dimension = -1,
+        string[] authenticationPairs = null,
+        object[] parameterPairs = null)
     {
         Provider = provider;
         ModelName = modelName;
         Metric = metric;
-    }
-
-    /// <summary>
-    /// Initializes a new instance with the specified provider, model name, metric, and authentication.
-    /// </summary>
-    /// <param name="provider">The name of the embedding service provider.</param>
-    /// <param name="modelName">The model name to use for embedding generation.</param>
-    /// <param name="metric">The similarity metric to use for vector comparisons.</param>
-    /// <param name="authenticationPairs">Key-value pairs for authenticating with the embedding service.</param>
-    public CollectionVectorizeAttribute(string provider, string modelName, SimilarityMetric metric, string[] authenticationPairs)
-    {
-        Provider = provider;
-        ModelName = modelName;
-        Metric = metric;
-        AuthenticationPairs = authenticationPairs;
-    }
-
-    /// <summary>
-    /// Initializes a new instance with the specified provider, model name, metric, authentication, and parameters.
-    /// </summary>
-    /// <param name="provider">The name of the embedding service provider.</param>
-    /// <param name="modelName">The model name to use for embedding generation.</param>
-    /// <param name="metric">The similarity metric to use for vector comparisons.</param>
-    /// <param name="authenticationPairs">Key-value pairs for authenticating with the embedding service.</param>
-    /// <param name="parameterPairs">Additional key-value parameter pairs for the embedding service.</param>
-    public CollectionVectorizeAttribute(string provider, string modelName, SimilarityMetric metric, string[] authenticationPairs, object[] parameterPairs)
-    {
-        Provider = provider;
-        ModelName = modelName;
-        Metric = metric;
-        AuthenticationPairs = authenticationPairs;
-        ParameterPairs = parameterPairs;
+        Dimension = dimension == -1 ? null : dimension;
+        AuthenticationPairs = authenticationPairs ?? Array.Empty<string>();
+        ParameterPairs = parameterPairs ?? Array.Empty<object>();
     }
 
 }

--- a/src/DataStax.AstraDB.DataApi/Core/CollectionVectorizeAttribute.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/CollectionVectorizeAttribute.cs
@@ -38,9 +38,9 @@ public class CollectionVectorizeAttribute : BaseVectorizeAttribute
     /// </summary>
     /// <param name="provider">The name of the embedding service provider.</param>
     /// <param name="modelName">The model name to use for embedding generation.</param>
-    /// <param name="dimension">The number of dimensions for the generated vector.</param>
-    /// <param name="authenticationPairs">Key-value pairs for authenticating with the embedding service.</param>
-    /// <param name="parameterPairs">Additional key-value parameter pairs for the embedding service.</param>
+    /// <param name="dimension">Optional: The number of dimensions for the generated vector.</param>
+    /// <param name="authenticationPairs">Optional: Key-value pairs for authenticating with the embedding service.</param>
+    /// <param name="parameterPairs">Optional: Additional key-value parameter pairs for the embedding service.</param>
     public CollectionVectorizeAttribute(
         string provider,
         string modelName,
@@ -60,10 +60,10 @@ public class CollectionVectorizeAttribute : BaseVectorizeAttribute
     /// </summary>
     /// <param name="provider">The name of the embedding service provider.</param>
     /// <param name="modelName">The model name to use for embedding generation.</param>
-    /// <param name="dimension">The number of dimensions for the generated vector.</param>
     /// <param name="metric">The similarity metric to use for vector comparisons.</param>
-    /// <param name="authenticationPairs">Key-value pairs for authenticating with the embedding service.</param>
-    /// <param name="parameterPairs">Additional key-value parameter pairs for the embedding service.</param>
+    /// <param name="dimension">Optional: The number of dimensions for the generated vector.</param>
+    /// <param name="authenticationPairs">Optional: Key-value pairs for authenticating with the embedding service.</param>
+    /// <param name="parameterPairs">Optional: Additional key-value parameter pairs for the embedding service.</param>
     public CollectionVectorizeAttribute(
         string provider,
         string modelName,

--- a/src/DataStax.AstraDB.DataApi/Core/CollectionVectorizeAttribute.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/CollectionVectorizeAttribute.cs
@@ -26,7 +26,7 @@ namespace DataStax.AstraDB.DataApi.Core;
 public class CollectionVectorizeAttribute : BaseVectorizeAttribute
 {
     /// <summary>The similarity metric to use for vector comparisons.</summary>
-    public SimilarityMetric Metric { get; set; } = SimilarityMetric.Cosine;
+    public SimilarityMetric? Metric { get; set; }
 
     /// <summary>
     /// Initializes a new instance of <see cref="CollectionVectorizeAttribute"/> with default settings.

--- a/src/DataStax.AstraDB.DataApi/Core/VectorOptions.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/VectorOptions.cs
@@ -33,7 +33,7 @@ public class VectorOptions
     /// The similarity metric to use
     /// </summary>
     [JsonPropertyName("metric")]
-    public SimilarityMetric Metric { get; set; }
+    public SimilarityMetric Metric { get; set; } = SimilarityMetric.Cosine;
 
     /// <summary>
     /// Options for the service providing the vectorization

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/TestObjects.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/TestObjects.cs
@@ -184,6 +184,20 @@ public class RowBookVectorize
     public float Rating { get; set; }
 }
 
+[TableName("bookTestTableVectorizeSharedSecret")]
+public class RowBookVectorizeSharedSecret
+{
+    [ColumnPrimaryKey(1)]
+    public string Title { get; set; }
+    [ColumnVectorize("openai", "text-embedding-3-small", dimension: 1536, authenticationPairs: new string[] {"providerKey=SHARED_SECRET_EMBEDDING_API_KEY_OPENAI"})]
+    public object Author { get; set; }
+    [ColumnPrimaryKey(2)]
+    public int NumberOfPages { get; set; }
+    public DateTime? DueDate { get; set; }
+    public HashSet<string> Genres { get; set; }
+    public float Rating { get; set; }
+}
+
 [TableName("bookTestTableSinglePrimaryKey")]
 public class RowBookSinglePrimaryKey
 {

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/TestObjects.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/TestObjects.cs
@@ -34,7 +34,11 @@ public class SimpleObjectWithVectorize
 }
 
 [CollectionName("coll_SimpleObjectWithVectorize")]
-[CollectionVectorize(Provider = "nvidia", ModelName = "nvidia/nv-embedqa-e5-v5", Metric = SimilarityMetric.Cosine)]
+[CollectionVectorize(
+    "nvidia",
+    "nvidia/nv-embedqa-e5-v5",
+    SimilarityMetric.Cosine
+)]
 public class SimpleObjectWithVectorizeAttribute
 {
     [DocumentId]
@@ -61,7 +65,7 @@ public class SimpleObjectWithVectorizeAttributeShSecret
 [CollectionName("coll_SimpleObjectWithVectorizeShSecret2A")]
 [CollectionVector(
     123,
-    Metric=SimilarityMetric.Euclidean,
+    SimilarityMetric.Euclidean,
     SourceModel="bert"
 )]
 [CollectionVectorize(

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/TestObjects.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/TestObjects.cs
@@ -203,7 +203,28 @@ public class RowBookVectorizeSharedSecret
 {
     [ColumnPrimaryKey(1)]
     public string Title { get; set; }
-    [ColumnVectorize("openai", "text-embedding-3-small", dimension: 1536, authenticationPairs: new string[] {"providerKey=SHARED_SECRET_EMBEDDING_API_KEY_OPENAI"})]
+    [ColumnVectorize(
+        "openai", "text-embedding-3-small", dimension: 1536,
+        authenticationPairs: new string[] {"providerKey", "SHARED_SECRET_EMBEDDING_API_KEY_OPENAI"}
+    )]
+    public object Author { get; set; }
+    [ColumnPrimaryKey(2)]
+    public int NumberOfPages { get; set; }
+    public DateTime? DueDate { get; set; }
+    public HashSet<string> Genres { get; set; }
+    public float Rating { get; set; }
+}
+
+[TableName("bookTestTableVeczeShdSecretWithParams")]
+public class RowBookVectorizeSharedSecretWithParameters
+{
+    [ColumnPrimaryKey(1)]
+    public string Title { get; set; }
+    [ColumnVectorize(
+        "voyageAI", "voyage-2",
+        authenticationPairs: new string[] { "providerKey", "SHARED_SECRET_EMBEDDING_API_KEY_VOYAGEAI" },
+        parameterPairs: new object[] { "autoTruncate", false }
+    )]
     public object Author { get; set; }
     [ColumnPrimaryKey(2)]
     public int NumberOfPages { get; set; }

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/TestObjects.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/TestObjects.cs
@@ -24,6 +24,31 @@ public class SimpleObjectWithVectorSearchResult : SimpleObjectWithVector
     public double? Similarity { get; set; }
 }
 
+[CollectionName("coll_SimpleObjectWithVectorAttributeSD")]
+[CollectionVector(
+    SimilarityMetric.Euclidean,
+    3
+)]
+public class SimpleObjectWithVectorAttributeSD
+{
+    [DocumentId]
+    public string Id { get; set; }
+    [DocumentMapping(DocumentMappingField.Vector)]
+    public float[] VectorEmbeddings { get; set; }
+}
+
+[CollectionName("coll_SimpleObjectWithVectorAttributeD")]
+[CollectionVector(
+    3
+)]
+public class SimpleObjectWithVectorAttributeD
+{
+    [DocumentId]
+    public string Id { get; set; }
+    [DocumentMapping(DocumentMappingField.Vector)]
+    public float[] VectorEmbeddings { get; set; }
+}
+
 public class SimpleObjectWithVectorize
 {
     [DocumentId]
@@ -64,8 +89,8 @@ public class SimpleObjectWithVectorizeAttributeShSecret
 
 [CollectionName("coll_SimpleObjectWithVectorizeShSecret2A")]
 [CollectionVector(
-    123,
     SimilarityMetric.Euclidean,
+    123,
     SourceModel="bert"
 )]
 [CollectionVectorize(

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/TestObjects.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/TestObjects.cs
@@ -1,6 +1,7 @@
 using DataStax.AstraDB.DataApi.Core;
 using DataStax.AstraDB.DataApi.SerDes;
 using DataStax.AstraDB.DataApi.Tables;
+using DataStax.AstraDB.DataApi.Collections;
 using MongoDB.Bson;
 using System.Text.Json.Serialization;
 
@@ -32,7 +33,8 @@ public class SimpleObjectWithVectorize
     public string StringToVectorize => Name;
 }
 
-[CollectionVectorize(Provider = "nvidia", ModelName = "NV-Embed-QA", Metric = SimilarityMetric.Cosine)]
+[CollectionName("coll_SimpleObjectWithVectorize")]
+[CollectionVectorize(Provider = "nvidia", ModelName = "nvidia/nv-embedqa-e5-v5", Metric = SimilarityMetric.Cosine)]
 public class SimpleObjectWithVectorizeAttribute
 {
     [DocumentId]
@@ -42,6 +44,49 @@ public class SimpleObjectWithVectorizeAttribute
     public string StringToVectorize => Name;
 }
 
+[CollectionName("coll_SimpleObjectWithVectorizeShSecret")]
+[CollectionVectorize(
+    Provider = "openai", ModelName = "text-embedding-3-small",
+    AuthenticationPairs = new string[] {"providerKey", "SHARED_SECRET_EMBEDDING_API_KEY_OPENAI"}
+)]
+public class SimpleObjectWithVectorizeAttributeShSecret
+{
+    [DocumentId]
+    public int? Id { get; set; }
+    public string Name { get; set; }
+    [DocumentMapping(DocumentMappingField.Vectorize)]
+    public string StringToVectorize => Name;
+}
+
+[CollectionName("coll_SimpleObjectWithVectorizeShSecret2A")]
+[CollectionVector(
+    123,
+    Metric=SimilarityMetric.Euclidean,
+    SourceModel="bert"
+)]
+[CollectionVectorize(
+    Provider = "openai", ModelName = "text-embedding-3-small",
+    AuthenticationPairs = new string[] {"providerKey", "SHARED_SECRET_EMBEDDING_API_KEY_OPENAI"}
+)]
+public class SimpleObjectWithVectorizeAttributeShSecret2A
+{
+    [DocumentId]
+    public int? Id { get; set; }
+    public string Name { get; set; }
+    [DocumentMapping(DocumentMappingField.Vectorize)]
+    public string StringToVectorize => Name;
+}
+
+[CollectionName("coll_SimpleObjectWithVectorizeHeader")]
+[CollectionVectorize(Provider = "openai", ModelName = "text-embedding-3-small")]
+public class SimpleObjectWithVectorizeAttributeHeader
+{
+    [DocumentId]
+    public int? Id { get; set; }
+    public string Name { get; set; }
+    [DocumentMapping(DocumentMappingField.Vectorize)]
+    public string StringToVectorize => Name;
+}
 
 [LexicalOptions(
     TokenizerName = "standard",

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/TestObjects.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/TestObjects.cs
@@ -184,6 +184,20 @@ public class RowBookVectorize
     public float Rating { get; set; }
 }
 
+[TableName("bookTestTableVectorizeHeaderBased")]
+public class RowBookVectorizeHeaderBased
+{
+    [ColumnPrimaryKey(1)]
+    public string Title { get; set; }
+    [ColumnVectorize("openai", "text-embedding-3-small", dimension: 1536)]
+    public object Author { get; set; }
+    [ColumnPrimaryKey(2)]
+    public int NumberOfPages { get; set; }
+    public DateTime? DueDate { get; set; }
+    public HashSet<string> Genres { get; set; }
+    public float Rating { get; set; }
+}
+
 [TableName("bookTestTableVectorizeSharedSecret")]
 public class RowBookVectorizeSharedSecret
 {

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/DatabaseTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/DatabaseTests.cs
@@ -380,7 +380,7 @@ public class DatabaseTests
 
     [SkipWhenNotAstra]
     [Fact(Skip="Should be run manually after scoping a certain OpenAI key to the database with the name quoted below")]
-    public async Task CreateCollection_WithVectorizesharedSecret_Untyped()
+    public async Task CreateCollection_WithVectorizeSharedSecret_Untyped()
     {
         var collectionName = "collectionVectorizesharedSecret_Untyped";
         var options = new CollectionDefinition
@@ -407,6 +407,44 @@ public class DatabaseTests
         await collection.InsertOneAsync(new Document
             {
                 { "$vectorize", "bla" }
+            });
+
+        await fixture.Database.DropCollectionAsync(collectionName);
+    }
+
+    [Fact(Skip="Should be run after exporting the environment variable quoted below")]
+    public async Task CreateGetCollection_WithVectorizeHeader_Untyped()
+    {
+        var embeddingAPIKey = Environment.GetEnvironmentVariable("HEADER_EMBEDDING_API_KEY_OPENAI") ?? "kaboom";
+        var headerOptions = new DatabaseCollectionCommandOptions() { EmbeddingApiKey = embeddingAPIKey };
+        var collectionName = "collection_WithVectorizeHeader_Untyped";
+        var options = new CollectionDefinition
+        {
+            Vector = new VectorOptions
+            {
+                Dimension = 1536,
+                Metric = SimilarityMetric.DotProduct,
+                Service = new VectorServiceOptions()
+                {
+                    Provider = "openai",
+                    ModelName = "text-embedding-3-small",
+                }
+            }
+        };
+        var createdCollection = await fixture.Database.CreateCollectionAsync(collectionName, options, headerOptions);
+        Assert.NotNull(createdCollection);
+        Assert.Equal(collectionName, createdCollection.CollectionName);
+        await createdCollection.InsertOneAsync(new Document
+            {
+                { "$vectorize", "bla one" }
+            });
+
+        var gottenCollection = fixture.Database.GetCollection(collectionName, headerOptions);
+        Assert.NotNull(gottenCollection);
+        Assert.Equal(collectionName, gottenCollection.CollectionName);
+        await gottenCollection.InsertOneAsync(new Document
+            {
+                { "$vectorize", "bla two" }
             });
 
         await fixture.Database.DropCollectionAsync(collectionName);
@@ -542,7 +580,7 @@ public class DatabaseTests
     }
 
     [SkipWhenNotAstra]
-    [Fact(Skip="Should be run manually after scoping a certain OpenAI key to the database with the name quoted below")]
+    [Fact(Skip="Should be run manually after scoping a certain OpenAI key to the database with the name quoted in RowBookVectorizeSharedSecretelow")]
     public async Task CreateTable_WithVectorizeSharedSecret_Typed()
     {
         try
@@ -555,6 +593,27 @@ public class DatabaseTests
         finally
         {
             await fixture.Database.DropTableAsync<RowBookVectorizeSharedSecret>();
+        }
+    }
+
+    [Fact(Skip="Should be run after exporting the environment variable quoted below")]
+    public async Task CreateGetTable_WithVectorizeHeader_Typed()
+    {
+        var embeddingAPIKey = Environment.GetEnvironmentVariable("HEADER_EMBEDDING_API_KEY_OPENAI") ?? "kaboom";
+        var gtHeaderOptions = new DatabaseTableCommandOptions() { EmbeddingApiKey = embeddingAPIKey };
+        var ctHeaderOptions = new CreateTableCommandOptions() { EmbeddingApiKey = embeddingAPIKey };
+        try
+        {
+            var createdTable = await fixture.Database.CreateTableAsync<RowBookVectorizeHeaderBased>(ctHeaderOptions);
+            await createdTable.InsertOneAsync(new RowBookVectorizeHeaderBased() {Title = "t one", Author = "a one", NumberOfPages = 123});
+
+            var gottenTable = fixture.Database.GetTable<RowBookVectorizeHeaderBased>(gtHeaderOptions);
+            await gottenTable.InsertOneAsync(new RowBookVectorizeHeaderBased() {Title = "t two", Author = "a two", NumberOfPages = 456});
+
+        }
+        finally
+        {
+            await fixture.Database.DropTableAsync<RowBookVectorizeHeaderBased>();
         }
     }
 
@@ -623,6 +682,46 @@ public class DatabaseTests
         finally
         {
             await fixture.Database.DropTableAsync(tableName);
+        }
+    }
+
+    [Fact(Skip="Should be run after exporting the environment variable quoted below")]
+    public async Task CreateGetTable_WithVectorizeHeader_Untyped()
+    {
+        var tableName = "bookTestTableVectorizeHeader_Untyped";
+        var embeddingAPIKey = Environment.GetEnvironmentVariable("HEADER_EMBEDDING_API_KEY_OPENAI") ?? "kaboom";
+        var gtHeaderOptions = new DatabaseTableCommandOptions() { EmbeddingApiKey = embeddingAPIKey };
+        var ctHeaderOptions = new CreateTableCommandOptions() { EmbeddingApiKey = embeddingAPIKey };
+        try
+        {
+            var createDefinition = new TableDefinition()
+                .AddColumn("Title", DataApiType.Text())
+                .AddColumn("NumberOfPages", DataApiType.Int())
+                .AddColumn("Author", DataApiType.Vectorize(1536, new VectorServiceOptions
+                {
+                    Provider = "openai",
+                    ModelName = "text-embedding-3-small",
+                }))
+                .AddCompositePrimaryKey(new [] {"Title", "NumberOfPages"});
+
+            var createdTable = await fixture.Database.CreateTableAsync(tableName, createDefinition, ctHeaderOptions);
+            await createdTable.InsertOneAsync(new Row() {
+                {"Title", "t one"},
+                {"Author", "a one"},
+                {"NumberOfPages", 123}
+            });
+
+            var gottenTable = fixture.Database.GetTable(tableName, gtHeaderOptions);
+            await gottenTable.InsertOneAsync(new Row() {
+                {"Title", "t two"},
+                {"Author", "a two"},
+                {"NumberOfPages", 456}
+            });
+
+        }
+        finally
+        {
+            await fixture.Database.DropTableAsync<RowBookVectorizeHeaderBased>();
         }
     }
 

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/DatabaseTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/DatabaseTests.cs
@@ -386,22 +386,6 @@ public class DatabaseTests
 
     [SkipWhenNotAstra]
     [Fact(Skip="Should be run manually after scoping a certain OpenAI key to the database with the name quoted below")]
-    /*
-        BUG: currently results in:
-            "vector": {
-                "dimension": 1536,
-                "metric": "cosine",
-                "service": {
-                    "provider": "openai",
-                    "modelName": "text-embedding-3-small",
-                    "authentication": {
-                        "providerKey": "SHARED_SECRET_EMBEDDING_API_KEY_OPENAI.providerKey"
-                    }
-                },
-                "sourceModel": "bert"
-            },
-        (i.e. no dimension and metric fetched from the `CollectionVector` attribute, sourceModel yes.)
-    */
     public async Task CreateCollection_WithVectorizeSharedSecretDoubleAttribute_Typed()
     {
         var collectionName = "coll_SimpleObjectWithVectorizeShSecret2A";
@@ -415,7 +399,7 @@ public class DatabaseTests
                 Name = "bla"
             });
 
-        //await fixture.Database.DropCollectionAsync(collectionName);
+        await fixture.Database.DropCollectionAsync(collectionName);
     }
 
     [Fact(Skip="Should be run after exporting the environment variable quoted below")]

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/DatabaseTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/DatabaseTests.cs
@@ -408,7 +408,7 @@ public class DatabaseTests
         var embeddingAPIKey = Environment.GetEnvironmentVariable("HEADER_EMBEDDING_API_KEY_OPENAI") ?? "kaboom";
         var headerOptions = new DatabaseCollectionCommandOptions() { EmbeddingApiKey = embeddingAPIKey };
         var collectionName = "coll_SimpleObjectWithVectorizeHeader";
-        // Signature of overloads mandate that we supply the collection name here. Eeh, I think we can live with that.
+        // Signature of overloads mandates that we supply the collection name here. Eeh, I think we can live with that.
         var createdCollection = await fixture.Database.CreateCollectionAsync<SimpleObjectWithVectorizeAttributeHeader>(collectionName, headerOptions);
         Assert.NotNull(createdCollection);
         Assert.Equal(collectionName, createdCollection.CollectionName);
@@ -418,7 +418,7 @@ public class DatabaseTests
                 Name = "bla one"
             });
 
-        // Signature of overloads mandate that we supply the collection name here. Eeh, I think we can live with that.
+        // Signature of overloads mandates that we supply the collection name here. Eeh, I think we can live with that.
         var gottenCollection = fixture.Database.GetCollection<SimpleObjectWithVectorizeAttributeHeader>(collectionName, headerOptions);
         Assert.NotNull(gottenCollection);
         Assert.Equal(collectionName, gottenCollection.CollectionName);

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/DatabaseTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/DatabaseTests.cs
@@ -348,8 +348,9 @@ public class DatabaseTests
         await fixture.Database.DropCollectionAsync(Constants.DefaultCollection);
     }
 
+    [SkipWhenNotAstra]
     [Fact]
-    public async Task CreateCollection_WithVectorizeHeader()
+    public async Task CreateCollection_WithVectorizeNone_Untyped()
     {
         var collectionName = "collectionVectorizeHeader";
         var options = new CollectionDefinition
@@ -368,29 +369,46 @@ public class DatabaseTests
         var collection = await fixture.Database.CreateCollectionAsync(collectionName, options);
         Assert.NotNull(collection);
         Assert.Equal(collectionName, collection.CollectionName);
+
+        await collection.InsertOneAsync(new Document
+            {
+                { "$vectorize", "bla" }
+            });
+
         await fixture.Database.DropCollectionAsync(collectionName);
     }
 
-    [Fact]
-    public async Task CreateCollection_WithVectorizeSharedKey()
+    [SkipWhenNotAstra]
+    [Fact(Skip="Should be run manually after scoping a certain OpenAI key to the database with the name quoted below")]
+    public async Task CreateCollection_WithVectorizesharedSecret_Untyped()
     {
-        var collectionName = "collectionVectorizeSharedKey";
+        var collectionName = "collectionVectorizesharedSecret_Untyped";
         var options = new CollectionDefinition
         {
             Vector = new VectorOptions
             {
-                Dimension = 1024,
+                Dimension = 1536,
                 Metric = SimilarityMetric.DotProduct,
                 Service = new VectorServiceOptions()
                 {
-                    Provider = "nvidia",
-                    ModelName = "NV-Embed-QA"
+                    Provider = "openai",
+                    ModelName = "text-embedding-3-small",
+                    Authentication = new Dictionary<string, string>
+                    {
+                        { "providerKey", "SHARED_SECRET_EMBEDDING_API_KEY_OPENAI" }
+                    }
                 }
             }
         };
         var collection = await fixture.Database.CreateCollectionAsync(collectionName, options);
         Assert.NotNull(collection);
         Assert.Equal(collectionName, collection.CollectionName);
+
+        await collection.InsertOneAsync(new Document
+            {
+                { "$vectorize", "bla" }
+            });
+
         await fixture.Database.DropCollectionAsync(collectionName);
     }
 
@@ -503,6 +521,108 @@ public class DatabaseTests
         finally
         {
             await fixture.Database.DropTableAsync<SimpleRowObject>();
+        }
+    }
+
+    [SkipWhenNotAstra]
+    [Fact]
+    public async Task CreateTable_WithVectorizeNone_Typed()
+    {
+        try
+        {
+            var table = await fixture.Database.CreateTableAsync<RowBookVectorize>();
+
+            await table.InsertOneAsync(new RowBookVectorize() {Title = "t", Author = "a", NumberOfPages = 123});
+
+        }
+        finally
+        {
+            await fixture.Database.DropTableAsync<RowBookVectorize>();
+        }
+    }
+
+    [SkipWhenNotAstra]
+    [Fact(Skip="Should be run manually after scoping a certain OpenAI key to the database with the name quoted below")]
+    public async Task CreateTable_WithVectorizeSharedSecret_Typed()
+    {
+        try
+        {
+            var table = await fixture.Database.CreateTableAsync<RowBookVectorizeSharedSecret>();
+
+            await table.InsertOneAsync(new RowBookVectorizeSharedSecret() {Title = "t", Author = "a", NumberOfPages = 123});
+
+        }
+        finally
+        {
+            await fixture.Database.DropTableAsync<RowBookVectorizeSharedSecret>();
+        }
+    }
+
+    [SkipWhenNotAstra]
+    [Fact]
+    public async Task CreateTable_WithVectorizeNone_Untyped()
+    {
+        var tableName = "bookTestTableVectorizeNone_Untyped";
+        try
+        {
+            var createDefinition = new TableDefinition()
+                .AddColumn("Title", DataApiType.Text())
+                .AddColumn("NumberOfPages", DataApiType.Int())
+                .AddColumn("Author", DataApiType.Vectorize(1024, new VectorServiceOptions
+                {
+                    Provider = "nvidia",
+                    ModelName = "NV-Embed-QA"
+                }))
+                .AddCompositePrimaryKey(new [] {"Title", "NumberOfPages"});
+
+            var table = await fixture.Database.CreateTableAsync(tableName, createDefinition);
+
+            await table.InsertOneAsync(new Row() {
+                {"Title", "t"},
+                {"Author", "a"},
+                {"NumberOfPages", 123}
+            });
+
+        }
+        finally
+        {
+            await fixture.Database.DropTableAsync(tableName);
+        }
+    }
+
+    [SkipWhenNotAstra]
+    [Fact(Skip="Should be run manually after scoping a certain OpenAI key to the database with the name quoted below")]
+    public async Task CreateTable_WithVectorizeSharedSecret_Untyped()
+    {
+        var tableName = "bookTestTableVectorizeSharedSecret_Untyped";
+        try
+        {
+            var createDefinition = new TableDefinition()
+                .AddColumn("Title", DataApiType.Text())
+                .AddColumn("NumberOfPages", DataApiType.Int())
+                .AddColumn("Author", DataApiType.Vectorize(1536, new VectorServiceOptions
+                {
+                    Provider = "openai",
+                    ModelName = "text-embedding-3-small",
+                    Authentication = new Dictionary<string, string>
+                    {
+                        { "providerKey", "SHARED_SECRET_EMBEDDING_API_KEY_OPENAI" }
+                    }
+                }))
+                .AddCompositePrimaryKey(new [] {"Title", "NumberOfPages"});
+
+            var table = await fixture.Database.CreateTableAsync(tableName, createDefinition);
+
+            await table.InsertOneAsync(new Row() {
+                {"Title", "t"},
+                {"Author", "a"},
+                {"NumberOfPages", 123}
+            });
+
+        }
+        finally
+        {
+            await fixture.Database.DropTableAsync(tableName);
         }
     }
 

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/DatabaseTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/DatabaseTests.cs
@@ -348,6 +348,40 @@ public class DatabaseTests
         await fixture.Database.DropCollectionAsync(Constants.DefaultCollection);
     }
 
+    [Fact(Skip="Generally skipped, this is to demonstrate creation")]
+    public async Task CreateCollection_WithVectorSD_Typed()
+    {
+        var collectionName = "coll_SimpleObjectWithVectorAttributeSD";
+        var collection = await fixture.Database.CreateCollectionAsync<SimpleObjectWithVectorAttributeSD>();
+        Assert.NotNull(collection);
+        Assert.Equal(collectionName, collection.CollectionName);
+
+        await collection.InsertOneAsync(new SimpleObjectWithVectorAttributeSD
+            {
+                Id = "the id",
+                VectorEmbeddings = new float[] { 0.1f, -0.2f, 0.3f }
+            });
+
+        await fixture.Database.DropCollectionAsync(collectionName);
+    }
+
+    [Fact(Skip="Generally skipped, this is to demonstrate creation")]
+    public async Task CreateCollection_WithVectorD_Typed()
+    {
+        var collectionName = "coll_SimpleObjectWithVectorAttributeD";
+        var collection = await fixture.Database.CreateCollectionAsync<SimpleObjectWithVectorAttributeD>();
+        Assert.NotNull(collection);
+        Assert.Equal(collectionName, collection.CollectionName);
+
+        await collection.InsertOneAsync(new SimpleObjectWithVectorAttributeD
+            {
+                Id = "the id",
+                VectorEmbeddings = new float[] { 0.1f, -0.2f, 0.3f }
+            });
+
+        await fixture.Database.DropCollectionAsync(collectionName);
+    }
+
     [SkipWhenNotAstra]
     [Fact(Skip="Generally skipped, this is to demonstrate creation")]
     public async Task CreateCollection_WithVectorizeNone_Typed()

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/DatabaseTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/DatabaseTests.cs
@@ -349,7 +349,106 @@ public class DatabaseTests
     }
 
     [SkipWhenNotAstra]
-    [Fact]
+    [Fact(Skip="Generally skipped, this is to demonstrate creation")]
+    public async Task CreateCollection_WithVectorizeNone_Typed()
+    {
+        var collectionName = "coll_SimpleObjectWithVectorize";
+        var collection = await fixture.Database.CreateCollectionAsync<SimpleObjectWithVectorizeAttribute>();
+        Assert.NotNull(collection);
+        Assert.Equal(collectionName, collection.CollectionName);
+
+        await collection.InsertOneAsync(new SimpleObjectWithVectorizeAttribute
+            {
+                Id = 123,
+                Name = "bla"
+            });
+
+        await fixture.Database.DropCollectionAsync(collectionName);
+    }
+
+    [SkipWhenNotAstra]
+    [Fact(Skip="Should be run manually after scoping a certain OpenAI key to the database with the name quoted below")]
+    public async Task CreateCollection_WithVectorizeSharedSecret_Typed()
+    {
+        var collectionName = "coll_SimpleObjectWithVectorizeShSecret";
+        var collection = await fixture.Database.CreateCollectionAsync<SimpleObjectWithVectorizeAttributeShSecret>();
+        Assert.NotNull(collection);
+        Assert.Equal(collectionName, collection.CollectionName);
+
+        await collection.InsertOneAsync(new SimpleObjectWithVectorizeAttributeShSecret
+            {
+                Id = 123,
+                Name = "bla"
+            });
+
+        await fixture.Database.DropCollectionAsync(collectionName);
+    }
+
+    [SkipWhenNotAstra]
+    [Fact(Skip="Should be run manually after scoping a certain OpenAI key to the database with the name quoted below")]
+    /*
+        BUG: currently results in:
+            "vector": {
+                "dimension": 1536,
+                "metric": "cosine",
+                "service": {
+                    "provider": "openai",
+                    "modelName": "text-embedding-3-small",
+                    "authentication": {
+                        "providerKey": "SHARED_SECRET_EMBEDDING_API_KEY_OPENAI.providerKey"
+                    }
+                },
+                "sourceModel": "bert"
+            },
+        (i.e. no dimension and metric fetched from the `CollectionVector` attribute, sourceModel yes.)
+    */
+    public async Task CreateCollection_WithVectorizeSharedSecretDoubleAttribute_Typed()
+    {
+        var collectionName = "coll_SimpleObjectWithVectorizeShSecret2A";
+        var collection = await fixture.Database.CreateCollectionAsync<SimpleObjectWithVectorizeAttributeShSecret2A>();
+        Assert.NotNull(collection);
+        Assert.Equal(collectionName, collection.CollectionName);
+
+        await collection.InsertOneAsync(new SimpleObjectWithVectorizeAttributeShSecret2A
+            {
+                Id = 123,
+                Name = "bla"
+            });
+
+        //await fixture.Database.DropCollectionAsync(collectionName);
+    }
+
+    [Fact(Skip="Should be run after exporting the environment variable quoted below")]
+    public async Task CreateGetCollection_WithVectorizeHeader_Typed()
+    {
+        var embeddingAPIKey = Environment.GetEnvironmentVariable("HEADER_EMBEDDING_API_KEY_OPENAI") ?? "kaboom";
+        var headerOptions = new DatabaseCollectionCommandOptions() { EmbeddingApiKey = embeddingAPIKey };
+        var collectionName = "coll_SimpleObjectWithVectorizeHeader";
+        // Signature of overloads mandate that we supply the collection name here. Eeh, I think we can live with that.
+        var createdCollection = await fixture.Database.CreateCollectionAsync<SimpleObjectWithVectorizeAttributeHeader>(collectionName, headerOptions);
+        Assert.NotNull(createdCollection);
+        Assert.Equal(collectionName, createdCollection.CollectionName);
+        await createdCollection.InsertOneAsync(new SimpleObjectWithVectorizeAttributeHeader
+            {
+                Id = 123,
+                Name = "bla one"
+            });
+
+        // Signature of overloads mandate that we supply the collection name here. Eeh, I think we can live with that.
+        var gottenCollection = fixture.Database.GetCollection<SimpleObjectWithVectorizeAttributeHeader>(collectionName, headerOptions);
+        Assert.NotNull(gottenCollection);
+        Assert.Equal(collectionName, gottenCollection.CollectionName);
+        await gottenCollection.InsertOneAsync(new SimpleObjectWithVectorizeAttributeHeader
+            {
+                Id = 321,
+                Name = "bla two"
+            });
+
+        await fixture.Database.DropCollectionAsync(collectionName);
+    }
+
+    [SkipWhenNotAstra]
+    [Fact(Skip="Generally skipped, this is to demonstrate creation")]
     public async Task CreateCollection_WithVectorizeNone_Untyped()
     {
         var collectionName = "collectionVectorizeHeader";
@@ -563,7 +662,7 @@ public class DatabaseTests
     }
 
     [SkipWhenNotAstra]
-    [Fact]
+    [Fact(Skip="Generally skipped, this is to demonstrate creation")]
     public async Task CreateTable_WithVectorizeNone_Typed()
     {
         try
@@ -635,7 +734,7 @@ public class DatabaseTests
     }
 
     [SkipWhenNotAstra]
-    [Fact]
+    [Fact(Skip="Generally skipped, this is to demonstrate creation")]
     public async Task CreateTable_WithVectorizeNone_Untyped()
     {
         var tableName = "bookTestTableVectorizeNone_Untyped";

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/DatabaseTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/DatabaseTests.cs
@@ -580,7 +580,7 @@ public class DatabaseTests
     }
 
     [SkipWhenNotAstra]
-    [Fact(Skip="Should be run manually after scoping a certain OpenAI key to the database with the name quoted in RowBookVectorizeSharedSecretelow")]
+    [Fact(Skip="Should be run manually after scoping a certain OpenAI key to the database with the name quoted in RowBookVectorizeSharedSecret")]
     public async Task CreateTable_WithVectorizeSharedSecret_Typed()
     {
         try
@@ -593,6 +593,23 @@ public class DatabaseTests
         finally
         {
             await fixture.Database.DropTableAsync<RowBookVectorizeSharedSecret>();
+        }
+    }
+
+    [SkipWhenNotAstra]
+    [Fact(Skip="Should be run manually after scoping a certain OpenAI key to the database with the name quoted in RowBookVectorizeSharedSecretWithParameters")]
+    public async Task CreateTable_WithVectorizeSharedSecretWithParameters_Typed()
+    {
+        try
+        {
+            var table = await fixture.Database.CreateTableAsync<RowBookVectorizeSharedSecretWithParameters>();
+
+            await table.InsertOneAsync(new RowBookVectorizeSharedSecretWithParameters() {Title = "t", Author = "a", NumberOfPages = 123});
+
+        }
+        finally
+        {
+            await fixture.Database.DropTableAsync<RowBookVectorizeSharedSecretWithParameters>();
         }
     }
 
@@ -666,6 +683,47 @@ public class DatabaseTests
                     Authentication = new Dictionary<string, string>
                     {
                         { "providerKey", "SHARED_SECRET_EMBEDDING_API_KEY_OPENAI" }
+                    }
+                }))
+                .AddCompositePrimaryKey(new [] {"Title", "NumberOfPages"});
+
+            var table = await fixture.Database.CreateTableAsync(tableName, createDefinition);
+
+            await table.InsertOneAsync(new Row() {
+                {"Title", "t"},
+                {"Author", "a"},
+                {"NumberOfPages", 123}
+            });
+
+        }
+        finally
+        {
+            await fixture.Database.DropTableAsync(tableName);
+        }
+    }
+
+
+    [SkipWhenNotAstra]
+    [Fact(Skip="Should be run manually after scoping a certain OpenAI key to the database with the name quoted below")]
+    public async Task CreateTable_WithVectorizeSharedSecretWithParameters_Untyped()
+    {
+        var tableName = "bookTestTableVeczeShdSecretWParams_Untyped";
+        try
+        {
+            var createDefinition = new TableDefinition()
+                .AddColumn("Title", DataApiType.Text())
+                .AddColumn("NumberOfPages", DataApiType.Int())
+                .AddColumn("Author", DataApiType.Vectorize(1024, new VectorServiceOptions
+                {
+                    Provider = "voyageAI",
+                    ModelName = "voyage-2",
+                    Authentication = new Dictionary<string, string>
+                    {
+                        { "providerKey", "SHARED_SECRET_EMBEDDING_API_KEY_VOYAGEAI" }
+                    },
+                    Parameters = new Dictionary<string, object>
+                    {
+                        { "autoTruncate", false }
                     }
                 }))
                 .AddCompositePrimaryKey(new [] {"Title", "NumberOfPages"});


### PR DESCRIPTION
This PR keeps track of the coverage for all vectorize-related situations. To do so it adds a bunch of create-X tests. Along the way, _changes in the code (besides tests)_ have been done.

```
{tables,collections} x {None, header, sharedSecret} x {create, get} x {typed, untyped}
    + nonstring 'parameters' where applies
    + superposition of CollectionVector and CollectionVectorize
```

The matrix is now complete and runs on the post-125-merged codebase entirely.

Note that most of the 15 added tests require some DB/ops setup (API keys and such). These new tests are all disabled by default anyway.

Examples are tested on Astra/HCD, anything that applies.

## Vectorize status:

```
COLLS   None                Typed   | OK    full test in branch
COLLS   shSecr              Typed   | OK    full test in branch
COLLS   shSecr(2attrs)      Typed   | OK    full test in branch
COLLS   Header(create+get)  Typed   | OK    full test in branch
------------------------------------+
COLLS   None                Untyped | OK    full test in branch
COLLS   shSecr              Untyped | OK    full test in branch
COLLS   Header(create+get)  Untyped | OK    full test in branch
====================================+
TABLE   None                Typed   | OK    full test in branch
TABLE   shSecr              Typed   | OK    full test in branch
TABLE   shSecr+params       Typed   | OK    full test in branch
TABLE   Header(create+get)  Typed   | OK    full test in branch
------------------------------------+
TABLE   None                Untyped | OK    full test in branch
TABLE   shSecr              Untyped | OK    full test in branch
TABLE   shSecr+params       Untyped | OK    full test in branch
TABLE   Header(create+get)  Untyped | OK    full test in branch
```

### Note on header-based auth

The header is passed as a certain field within certain `*CommandOption` classes. There is an asymmetry here between tables and collections:

```
                    DatabaseCommandOptions
                    /                    \
DatabaseCollectionCommandOptions        DatabaseTableCommandOptions
                                          |
                                        CreateTableCommandOptions
```

All three "bottom" classes support the `new <className>() { EmbeddingApiKey = embeddingAPIKey }` pattern to be passed to the appropriate `Get/Create x Table/Collection` method: however there are two different ones for tables ... because of "ifNotExists" (which does not make sense when `Get`ting a table, nor does it for a collection).


