### PR TITLE
A tiny test fix (about NANfinities in collections)

### DIFF
--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdditionalCollectionTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdditionalCollectionTests.cs
@@ -347,8 +347,8 @@ public class AdditionalCollectionTests
 
             var okUntypedDocs = new List<Document>
             {
-                new() { ["DoubleValue"] = "+Infinity", ["FloatValue"] = "+Infinity" },
-                new() { ["DoubleValue"] = "-Infinity", ["FloatValue"] = "-NegativeInfinity" },
+                new() { ["DoubleValue"] = "Infinity", ["FloatValue"] = "Infinity" },
+                new() { ["DoubleValue"] = "-Infinity", ["FloatValue"] = "-Infinity" },
                 new() { ["DoubleValue"] = "NaN", ["FloatValue"] = "NaN" },
             };
 


### PR DESCRIPTION
I'm sure this is what was meant to be tested (no big deal)

Now a real question. Inspecting the payload shows that the original insertion is serialized as:

```
{
    "insertMany": {
        "documents": [
            {
                "DoubleValue": "\u002BInfinity",
                "FloatValue": "\u002BInfinity"
            },
            {
                "DoubleValue": "-Infinity",
                "FloatValue": "-NegativeInfinity"
            },
            {
                "DoubleValue": "NaN",
                "FloatValue": "NaN"
            }
        ],
        "options": {
            "ordered": false
        }
    }
}
```

This is identical, in effect, to writing a literal `+` rather than its escape, but I do wonder: how come the plus sign, and only the plus sign, is escaped? It's not a high-value obscure unicode sequence or something, no?
(this may hint at something potentially troublesome in the serdes machinery? Probably not...)
(also it sounds like a (tiny) waste of bytes. Oh, well).
