### PR TITLE
Fix serialization of options for createIndex

### DIFF
--- a/src/DataStax.AstraDB.DataApi/Tables/TableIndexOptions.cs
+++ b/src/DataStax.AstraDB.DataApi/Tables/TableIndexOptions.cs
@@ -31,21 +31,21 @@ public class TableIndexOptions
     /// Should the index be case sensitive?
     /// </summary>
     [JsonPropertyName("caseSensitive")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    public bool CaseSensitive { get; set; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? CaseSensitive { get; set; } = null;
 
     /// <summary>
     /// Should the index normalize the text?
     /// </summary>
     [JsonPropertyName("normalize")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    public bool Normalize { get; set; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? Normalize { get; set; } = null;
 
     /// <summary>
     /// Should the index use ASCII conversion?
     /// </summary>
     [JsonPropertyName("ascii")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    public bool Ascii { get; set; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? Ascii { get; set; } = null;
 
 }

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/TableIndexesTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/TableIndexesTests.cs
@@ -206,6 +206,32 @@ public class TableIndexesTests
 
             var insertResult = await TableIndexesFixture.AddTableRows(table);
             Assert.Equal(3, insertResult.InsertedCount);
+
+            // a few failing creations to test payload construction (logs must be manually inspected for this)
+            await Assert.ThrowsAsync<CommandException>(() =>
+                table.CreateIndexAsync(indexName, "category", Builders.TableIndex.Index(new TableIndexOptions() { }) ));
+                // results in : {"createIndex":{"name":"category_idx","definition":{"options":{},"column":"category"}}}
+            await Assert.ThrowsAsync<CommandException>(() =>
+                table.CreateIndexAsync(indexName, "category", Builders.TableIndex.Index(new TableIndexOptions() { CaseSensitive = false }) ));
+                // results in : {"createIndex":{"name":"category_idx","definition":{"options":{"caseSensitive":false},"column":"category"}}}
+            await Assert.ThrowsAsync<CommandException>(() =>
+                table.CreateIndexAsync(indexName, "category", Builders.TableIndex.Index(new TableIndexOptions() { CaseSensitive = false, Ascii = false }) ));
+                // results in : {"createIndex":{"name":"category_idx","definition":{"options":{"caseSensitive":false,"ascii":false},"column":"category"}}}
+            await Assert.ThrowsAsync<CommandException>(() =>
+                table.CreateIndexAsync(indexName, "category", Builders.TableIndex.Index(new TableIndexOptions() { CaseSensitive = false, Ascii = false, Normalize = false }) ));
+                // results in : {"createIndex":{"name":"category_idx","definition":{"options":{"caseSensitive":false,"normalize":false,"ascii":false},"column":"category"}}}
+            await Assert.ThrowsAsync<CommandException>(() =>
+                table.CreateIndexAsync(indexName, "category", Builders.TableIndex.Index(new TableIndexOptions() { CaseSensitive = true }) ));
+                // results in : {"createIndex":{"name":"category_idx","definition":{"options":{"caseSensitive":true},"column":"category"}}}
+            await Assert.ThrowsAsync<CommandException>(() =>
+                table.CreateIndexAsync(indexName, "category", Builders.TableIndex.Index(new TableIndexOptions() { CaseSensitive = true, Ascii = true, Normalize = true }) ));
+                // results in : {"createIndex":{"name":"category_idx","definition":{"options":{"caseSensitive":true,"normalize":true,"ascii":true},"column":"category"}}}
+            await Assert.ThrowsAsync<CommandException>(() =>
+                table.CreateIndexAsync(indexName, "category", Builders.TableIndex.Index(new TableIndexOptions() { CaseSensitive = false, Ascii = true }) ));
+                // results in : {"createIndex":{"name":"category_idx","definition":{"options":{"caseSensitive":false,"ascii":true},"column":"category"}}}
+            await Assert.ThrowsAsync<CommandException>(() =>
+                table.CreateIndexAsync(indexName, "category", Builders.TableIndex.Index(new TableIndexOptions() { CaseSensitive = false, Ascii = false, Normalize = true }) ));
+                // results in : {"createIndex":{"name":"category_idx","definition":{"options":{"caseSensitive":false,"normalize":true,"ascii":false},"column":"category"}}}
         }
         finally
         {


### PR DESCRIPTION
The boolean index options must be serialized when provided by the user in the TableIndexOptions object, regardless of their value.

With `JsonIgnoreCondition.WhenWritingDefault`, false options do not end up in the index creation payload at all. This PR fixes that (and adds extensive albeit manual testing of multiple combinations of options).