### PR TITLE
End-to-end testing of bin/list encoding of vectors & blobs

### DIFF
--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/TestObjects.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/TestObjects.cs
@@ -734,3 +734,19 @@ public class VectorObjectAsBin
     public float[] TheVector { get; set; }
     public byte[] TheBlob { get; set; }
 }
+
+[TableName("testTable_vecEncoding_t")]
+public class VectorEncodingTestRow
+{
+    [ColumnPrimaryKey]
+    public string id { get; set; }
+    [ColumnVector(3)]
+    [JsonConverter(typeof(FloatArrayWriter))]
+    public float[] TheLstVec { get; set; }
+    [ColumnVector(3)]
+    [JsonConverter(typeof(FloatBinaryWriter))]
+    public float[] TheBinVec { get; set; }
+
+    public float[] JustAList { get; set; }
+    public byte[] TheBlob { get; set; }
+}

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/TestObjects.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/TestObjects.cs
@@ -1,3 +1,4 @@
+using DataStax.AstraDB.DataApi.Collections;
 using DataStax.AstraDB.DataApi.Core;
 using DataStax.AstraDB.DataApi.SerDes;
 using DataStax.AstraDB.DataApi.Tables;
@@ -710,3 +711,26 @@ public class TripleMapObject
     public Dictionary<string, string> map_v { get; set; }
 }
 
+[CollectionName("testColl_vecEncoding")]
+// TODO: employ `CollectionVector` class-level attribute once PR 136 is merged and create through object in test
+public class VectorObjectAsLst
+{
+    [DocumentId]
+    public string _id { get; set; }
+    [JsonConverter(typeof(FloatArrayWriter))]
+    [DocumentMapping(DocumentMappingField.Vector)]
+    public float[] TheVector { get; set; }
+    public byte[] TheBlob { get; set; }
+}
+
+[CollectionName("testColl_vecEncoding")]
+// TODO: employ `CollectionVector` class-level attribute once PR 136 is merged and create through object in test
+public class VectorObjectAsBin
+{
+    [DocumentId]
+    public string _id { get; set; }
+    [DocumentMapping(DocumentMappingField.Vector)]
+    [JsonConverter(typeof(FloatBinaryWriter))]
+    public float[] TheVector { get; set; }
+    public byte[] TheBlob { get; set; }
+}

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/TestObjects.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/TestObjects.cs
@@ -711,8 +711,8 @@ public class TripleMapObject
     public Dictionary<string, string> map_v { get; set; }
 }
 
-[CollectionName("testColl_vecEncoding")]
-// TODO: employ `CollectionVector` class-level attribute once PR 136 is merged and create through object in test
+[CollectionName("testColl_vecEncoding_Typed")]
+[CollectionVector(3)]
 public class VectorObjectAsLst
 {
     [DocumentId]
@@ -723,8 +723,8 @@ public class VectorObjectAsLst
     public byte[] TheBlob { get; set; }
 }
 
-[CollectionName("testColl_vecEncoding")]
-// TODO: employ `CollectionVector` class-level attribute once PR 136 is merged and create through object in test
+[CollectionName("testColl_vecEncoding_Typed")]
+[CollectionVector(3)]
 public class VectorObjectAsBin
 {
     [DocumentId]

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdditionalCollectionTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdditionalCollectionTests.cs
@@ -1,7 +1,9 @@
 using DataStax.AstraDB.DataApi.Collections;
 using DataStax.AstraDB.DataApi.Core;
+using DataStax.AstraDB.DataApi.Core.Query;
 using DataStax.AstraDB.DataApi.Core.Results;
 using DataStax.AstraDB.DataApi.IntegrationTests.Fixtures;
+using System.Text;
 using System.Text.Json;
 using Xunit;
 
@@ -368,6 +370,126 @@ public class AdditionalCollectionTests
             await fixture.Database.DropCollectionAsync(collectionName);
         }
     }
+
+    [Fact]
+    public async Task Test_VectorEncodingCollection_Typed()
+    {
+        // Note: full check of this test involves manual log inspection for the payloads.
+        var collectionName = "testColl_vecEncoding_Typed";
+        try
+        {
+            /* TODO replace this creation with something like this (both!) once PR 136 gets in and we get fully typed (vector-)collection creation
+                var vecLstEncColl = await fixture.Database.CreateCollectionAsync<VectorObjectAsLst>();
+                var vecBinEncColl = await fixture.Database.CreateCollectionAsync<VectorObjectAsBin>();
+            */
+            var collDefinition = new CollectionDefinition { Vector = new VectorOptions { Dimension = 3 } };
+            var createdCollection = await fixture.Database.CreateCollectionAsync(collectionName, collDefinition);
+            var vecLstEncColl = fixture.Database.GetCollection<VectorObjectAsLst>(collectionName);
+            var vecBinEncColl = fixture.Database.GetCollection<VectorObjectAsBin>(collectionName);
+
+            var lstDocument = new VectorObjectAsLst
+            {
+                _id = "as_lst",
+                TheVector = new float[] { 0.3f, -0.2f, 0.1f },
+                TheBlob = Encoding.ASCII.GetBytes("a doc with a LST vector")
+            };
+            var binDocument = new VectorObjectAsBin
+            {
+                _id = "as_bin",
+                TheVector = new float[] { 0.3f, -0.2f, 0.1f },
+                TheBlob = Encoding.ASCII.GetBytes("a doc with a BIN vector")
+            };
+
+            // TODO: logs show that this payload looks like: `{"_id":"as_lst","$vector":{"$binary":"PpmZmr5MzM09zMzN"},"TheBlob":{"$binary":"YSBkb2Mgd2l0aCBhIExTVCB2ZWN0b3I="}}`
+            //  Expectation: `{..., "$vector": [0.3, -0.2, 0.1], ...}
+            await vecLstEncColl.InsertOneAsync(lstDocument);
+            // all good with the payload for this write.
+            await vecBinEncColl.InsertOneAsync(binDocument);
+
+            // TODO the following will need to be re-run once the above is understood and the payloads are $binary vs [floats].
+            // Reads:
+            var lstReadAsLst = await vecLstEncColl.FindOneAsync(
+                Builders<VectorObjectAsLst>.CollectionFilter.Eq(d => d._id, "as_lst"));
+            var lstReadAsBin = await vecBinEncColl.FindOneAsync(
+                Builders<VectorObjectAsBin>.CollectionFilter.Eq(d => d._id, "as_lst"));
+            var binReadAsLst = await vecLstEncColl.FindOneAsync(
+                Builders<VectorObjectAsLst>.CollectionFilter.Eq(d => d._id, "as_bin"));
+            var binReadAsBin = await vecBinEncColl.FindOneAsync(
+                Builders<VectorObjectAsBin>.CollectionFilter.Eq(d => d._id, "as_bin"));
+
+            // all 'four' (two) vectors are the same values:
+            Assert.Equal(lstReadAsLst.TheVector, lstReadAsBin.TheVector);
+            Assert.Equal(lstReadAsLst.TheVector, binReadAsLst.TheVector);
+            Assert.Equal(lstReadAsLst.TheVector, binReadAsBin.TheVector);
+
+            // two different blobs must be read consistently
+            Assert.Equal(lstReadAsLst.TheBlob, lstReadAsBin.TheBlob);
+            Assert.Equal(binReadAsLst.TheBlob, binReadAsBin.TheBlob);
+
+        }
+        finally
+        {
+            await fixture.Database.DropCollectionAsync(collectionName);
+        }
+    }
+
+    [Fact]
+    public async Task Test_VectorEncodingCollection_Untyped()
+    {
+        // Note: full check of this test involves manual log inspection for the payloads.
+        var collectionName = "testColl_vecEncoding_Untyped";
+        try
+        {
+            var collDefinition = new CollectionDefinition { Vector = new VectorOptions { Dimension = 3 } };
+            var createdCollection = await fixture.Database.CreateCollectionAsync(collectionName, collDefinition);
+
+            await createdCollection.InsertOneAsync(new Document
+                {
+                    { "_id", "as_lst" },
+                    { "$vector", new float[] { 0.3f, -0.2f, 0.1f } },
+                    { "TheBlob", Encoding.ASCII.GetBytes("a doc with a LST vector") },
+                });
+            await createdCollection.InsertOneAsync(new Document
+                {
+                    { "_id", "as_bin" },
+                    { "$vector", new Dictionary<string,string> { ["$binary"] = "PpmZmr5MzM09zMzN" } },
+                    { "TheBlob", Encoding.ASCII.GetBytes("a doc with a BIN vector") },
+                });
+
+            // Reads:
+            var findOptionsLst = new DocumentFindOptions<Document>()
+            {
+                Filter = Builders<Document>.CollectionFilter.Eq("_id", "as_lst"),
+                Projection = Builders<Document>.Projection.Include("$vector")
+            };
+            var findOptionsBin = new DocumentFindOptions<Document>()
+            {
+                Filter = Builders<Document>.CollectionFilter.Eq("_id", "as_bin"),
+                Projection = Builders<Document>.Projection.Include("$vector")
+            };
+            var lstRead = await createdCollection.FindOneAsync(findOptionsLst);
+            var binRead = await createdCollection.FindOneAsync(findOptionsBin);
+
+            // same values should be found:
+            // TODO these 2 fail. Deserializaion *should* figure out this is a $vector
+            //      and decode accordingly to a `float[]`, even if untyped.
+            //      Currently this comes back as [["$binary"] = PpmZmr5MzM09zMzN]
+            // Assert.Equal(new float[] { 0.3f, -0.2f, 0.1f }, lstRead["$vector"]);
+            // Assert.Equal(lstRead["$vector"], binRead["$vector"]);
+
+            // two different blobs must be read consistently
+            // TODO these two fail. This is returned to the user as a `[["$binary"] = YSBkb2Mgd2l0aCBhIEJJTiB2ZWN0b3I=]` dict.
+            //      Deserialization should figure out this is to become a `byte[]` and decode.
+            // Assert.Equal(Encoding.ASCII.GetBytes("a doc with a LST vector"), lstRead["TheBlob"]);
+            // Assert.Equal(Encoding.ASCII.GetBytes("a doc with a BIN vector"), binRead["TheBlob"]);
+
+        }
+        finally
+        {
+            await fixture.Database.DropCollectionAsync(collectionName);
+        }
+    }
+
 }
 
 [CollectionName("testCollectionNameViaAttribute")]

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdditionalCollectionTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdditionalCollectionTests.cs
@@ -378,13 +378,7 @@ public class AdditionalCollectionTests
         var collectionName = "testColl_vecEncoding_Typed";
         try
         {
-            /* TODO replace this creation with something like this (both!) once PR 136 gets in and we get fully typed (vector-)collection creation
-                var vecLstEncColl = await fixture.Database.CreateCollectionAsync<VectorObjectAsLst>();
-                var vecBinEncColl = await fixture.Database.CreateCollectionAsync<VectorObjectAsBin>();
-            */
-            var collDefinition = new CollectionDefinition { Vector = new VectorOptions { Dimension = 3 } };
-            var createdCollection = await fixture.Database.CreateCollectionAsync(collectionName, collDefinition);
-            var vecLstEncColl = fixture.Database.GetCollection<VectorObjectAsLst>(collectionName);
+            var vecLstEncColl = fixture.Database.CreateCollection<VectorObjectAsLst>();
             var vecBinEncColl = fixture.Database.GetCollection<VectorObjectAsBin>(collectionName);
 
             var lstDocument = new VectorObjectAsLst
@@ -459,23 +453,31 @@ public class AdditionalCollectionTests
             // Reads:
             var findOptionsLst = new DocumentFindOptions<Document>()
             {
-                Filter = Builders<Document>.CollectionFilter.Eq("_id", "as_lst"),
-                Projection = Builders<Document>.Projection.Include("$vector")
-            };
+                Projection = Builders<Document>.Projection.Include("$vector") };
             var findOptionsBin = new DocumentFindOptions<Document>()
             {
-                Filter = Builders<Document>.CollectionFilter.Eq("_id", "as_bin"),
-                Projection = Builders<Document>.Projection.Include("$vector")
-            };
-            var lstRead = await createdCollection.FindOneAsync(findOptionsLst);
-            var binRead = await createdCollection.FindOneAsync(findOptionsBin);
+                Projection = Builders<Document>.Projection.Include("$vector") };
+            var lstRead = await createdCollection.FindOneAsync(
+                Builders<Document>.CollectionFilter.Eq("_id", "as_lst"),
+                findOptionsLst);
+            var binRead = await createdCollection.FindOneAsync(
+                Builders<Document>.CollectionFilter.Eq("_id", "as_bin"),
+                findOptionsBin);
 
-            // same values should be found:
-            // TODO these 2 fail. Deserializaion *should* figure out this is a $vector
-            //      and decode accordingly to a `float[]`, even if untyped.
+            // same values should be found for the vector (modulo some machine-precision epsilon)
+
+            // ok for the LST reading (though these come out as doubles):
+            // Assert.IsType<float>( ((object[])lstRead["$vector"]) [0]);
+            var readVector = (Object[])lstRead["$vector"];
+            Assert.Equal(3, readVector.Length);
+            Assert.True( Math.Abs( 0.3 - (double)(readVector[0])) < 1.0e-5);
+            Assert.True( Math.Abs(-0.2 - (double)(readVector[1])) < 1.0e-5);
+            Assert.True( Math.Abs( 0.1 - (double)(readVector[2])) < 1.0e-5);
+
+            // TODO the BIN read fails. Deserialization *should* figure out this is a $vector
+            //      and decode, accordingly, into a `float[]`, even if untyped.
             //      Currently this comes back as [["$binary"] = PpmZmr5MzM09zMzN]
-            // Assert.Equal(new float[] { 0.3f, -0.2f, 0.1f }, lstRead["$vector"]);
-            // Assert.Equal(lstRead["$vector"], binRead["$vector"]);
+            // Assert.Equal(lstRead["$vector"], binRead["$vector"]); // check would still need an epsilon treatment maybe?
 
             // two different blobs must be read consistently
             // TODO these two fail. This is returned to the user as a `[["$binary"] = YSBkb2Mgd2l0aCBhIEJJTiB2ZWN0b3I=]` dict.
@@ -486,7 +488,7 @@ public class AdditionalCollectionTests
         }
         finally
         {
-            await fixture.Database.DropCollectionAsync(collectionName);
+            //await fixture.Database.DropCollectionAsync(collectionName);
         }
     }
 

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdditionalTableTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdditionalTableTests.cs
@@ -1064,7 +1064,7 @@ public class AdditionalTableTests
         }
         finally
         {
-            //await fixture.Database.DropTableAsync(tableName);
+            await fixture.Database.DropTableAsync(tableName);
         }
     }
 
@@ -1139,7 +1139,7 @@ public class AdditionalTableTests
         }
         finally
         {
-            //await fixture.Database.DropTableAsync(tableName);
+            await fixture.Database.DropTableAsync(tableName);
         }
     }
 

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdditionalTableTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdditionalTableTests.cs
@@ -6,6 +6,7 @@ using DataStax.AstraDB.DataApi.Tables;
 using DataStax.AstraDB.DataApi.Utils;
 using Microsoft.VisualBasic;
 using System.IO;
+using System.Text;
 using System.Text.Json;
 using Xunit;
 
@@ -1024,6 +1025,121 @@ public class AdditionalTableTests
         finally
         {
             await fixture.Database.DropTableAsync(tableName);
+        }
+    }
+
+    [Fact]
+    public async Task Test_VectorEncodingTable_Typed()
+    {
+        // Note: full check of this test involves manual log inspection for the payloads.
+        var tableName = "testTable_vecEncoding_t";
+        try
+        {
+            var createdTable = await fixture.Database.CreateTableAsync<VectorEncodingTestRow>();
+
+            var theRow = new VectorEncodingTestRow
+            {
+                id = "the_t_row",
+                TheLstVec = new float[] { 0.3f, -0.2f, 0.1f },
+                TheBinVec = new float[] { 0.3f, -0.2f, 0.1f },
+                JustAList = new float[] { 0.3f, -0.2f, 0.1f },
+                TheBlob = Encoding.ASCII.GetBytes("a nice typed row")
+            };
+
+            // TODO manual inspection shows that both vector columns serialize as binary-encoded.
+            //      That is, column `TheLstVec` appears as `"TheLstVec":{"$binary":"PpmZmr5MzM09zMzN"}` in the payload,
+            //      despite being annotated as `FloatArrayWriter`.
+            await createdTable.InsertOneAsync(theRow);
+
+            // Reads:
+            var readRow = await createdTable.FindOneAsync(
+                Builders<VectorEncodingTestRow>.TableFilter.Eq(d => d.id, "the_t_row"));
+
+            // all lists/vectors are the same:
+            Assert.Equal(readRow.TheLstVec, readRow.TheBinVec);
+            Assert.Equal(readRow.TheLstVec, readRow.JustAList);
+            // blob i/o consistent:
+            Assert.Equal(Encoding.ASCII.GetBytes("a nice typed row"), readRow.TheBlob);
+
+        }
+        finally
+        {
+            //await fixture.Database.DropTableAsync(tableName);
+        }
+    }
+
+    [Fact]
+    public async Task Test_VectorEncodingTable_Untyped()
+    {
+        // Note: full check of this test involves manual log inspection for the payloads.
+        var tableName = "testTable_vecEncoding_u";
+        try
+        {
+            var tableDefinition = new TableDefinition()
+                .AddColumn("id", DataApiType.Text())
+                .AddColumn("TheLstVec", DataApiType.Vector(3))
+                .AddColumn("TheBinVec", DataApiType.Vector(3))
+                .AddColumn("JustAList", DataApiType.List(DataApiType.Float()))
+                .AddColumn("TheBlob", DataApiType.Blob())
+                .AddSinglePrimaryKey("id");
+            var createdTable = await fixture.Database.CreateTableAsync(tableName, tableDefinition);
+
+            var theRow = new Row
+            {
+                {"id" , "the_u_row"},
+                {"TheLstVec" , new float[] { 0.3f, -0.2f, 0.1f }},
+                {"TheBinVec" , new float[] { 0.3f, -0.2f, 0.1f }},
+                {"JustAList" , new float[] { 0.3f, -0.2f, 0.1f }},
+                {"TheBlob" , Encoding.ASCII.GetBytes("a nice untyped row")}
+            };
+
+            // All vectors and lists serialize as JSON lists in this untyped scenario.
+            // TODO confirm there's no other choice available
+            await createdTable.InsertOneAsync(theRow);
+
+            // Reads:
+            var readRow = await createdTable.FindOneAsync(
+                Builders<Row>.TableFilter.Eq("id", "the_u_row"));
+
+            // all lists/vectors are the same (save for machine-precision epsilons):
+            var lstElement = (JsonElement)readRow["TheLstVec"];
+            var binElement = (JsonElement)readRow["TheBinVec"];
+            var arrElement = (JsonElement)readRow["JustAList"];
+
+            Assert.Equal(JsonValueKind.Array, lstElement.ValueKind);
+            Assert.Equal(JsonValueKind.Array, binElement.ValueKind);
+            Assert.Equal(JsonValueKind.Array, arrElement.ValueKind);
+
+            var lstArray = lstElement
+                .EnumerateArray()
+                .Select(x => x.GetSingle())
+                .ToArray();
+            var binArray = binElement
+                .EnumerateArray()
+                .Select(x => x.GetSingle())
+                .ToArray();
+            var arrArray = arrElement
+                .EnumerateArray()
+                .Select(x => x.GetSingle())
+                .ToArray();
+            Assert.Equal(lstArray.Length, binArray.Length);
+            Assert.Equal(lstArray.Length, arrArray.Length);
+            var l1DistanceLB = lstArray
+                .Zip(binArray, (e, a) => Math.Abs(e - a))
+                .Sum();
+            var l1DistanceLA = lstArray
+                .Zip(arrArray, (e, a) => Math.Abs(e - a))
+                .Sum();
+            Assert.True(l1DistanceLB < 1e-5f, $"L1 distance was {l1DistanceLB}");
+            Assert.True(l1DistanceLA < 1e-5f, $"L1 distance was {l1DistanceLA}");
+
+            // blob i/o consistent:
+            Assert.Equal(Encoding.ASCII.GetBytes("a nice untyped row"), readRow["TheBlob"]);
+
+        }
+        finally
+        {
+            //await fixture.Database.DropTableAsync(tableName);
         }
     }
 


### PR DESCRIPTION
Closes #132 .

This adds tests that write vectors/`float[]`/blobs for typed/untyped tables/collections trying out all combinations and available choices regarding serialization (i.e. as JSON lists of floats VS. as `"$binary": ...`).

The items below are verified with the tests in this PR.

- Collections:
    - Typed:
        - Since the required `DocumentMapping(DocumentMappingField.Vector)` overrides any `[JsonConverter(typeof(Float***Writer))]`, one has no choice and for vectors it will be binary-encoding
        - (`float[]` serialize as lists, `byte[]` as `"$binary"`, no surprises)
        - (So one can choose the encoding only for lists appearing elsewhere in the document - which the API will write as is! <- use with care)
- Untyped:
        - when reading a binenc-vector or a blob, one gets back very raw `[["$binary"] = PpmZmr5MzM09zMzN]`
and `[["$binary"] = YSBkb2Mgd2l0aCBhIEJJTiB2ZWN0b3I=]` things, no basic rehydration takes place right now.
        - (and when reading a $vector coming as list, one gets them as double rather than floats, hidden behind the type obfuscation of untyped reads anyway)
- Tables:
    - Typed:
        - Despite the `JsonConverter(typeof(FloatArrayWriter))` annotation, the `ColumnVector` seems overrides the behaviour and force binary-encoding
        - (So one can choose the encoding only for nonvector lists, i.e. `float[]`/`double[]` columns ... which currently the Data API accepts only as lists and not $binary).
    - Untyped:
        - Vectors and `float[]` can only get into the payload as JSON lists (all good. There's no DataAPIVector marker class)

As a consequence of the above rules,

1. there's no way to switch off the bin-encoding in typed tables/collections (not a big deal, to be clear)
2. typed reads are resilient to both formats (good)
3. untyped lets you write with more freedom (at the expense of some manual work)
4. but you're on your own with untyped reads (to be changed later on...)
