### PR TITLE
FindOne carefully accepts filter in two ways, never silently loses one

### DIFF
--- a/src/DataStax.AstraDB.DataApi/Collections/Collection.cs
+++ b/src/DataStax.AstraDB.DataApi/Collections/Collection.cs
@@ -597,7 +597,17 @@ public class Collection<T, TId> : IQueryRunner<T, CollectionSortBuilder<T>> wher
 
     private async Task<TResult> FindOneAsync<TResult>(CollectionFilter<T> filter, DocumentFindOptions<T> findOptions, CommandOptions commandOptions, bool runSynchronously)
     {
-        findOptions.Filter = filter;
+        findOptions = findOptions != null ? findOptions.Clone() : new DocumentFindOptions<T>();
+        if (filter != null)
+        {
+            if (findOptions.Filter == null)
+            {
+                findOptions.Filter = filter;
+            } else
+            {
+                throw new ArgumentException("Cannot pass a filter both within FindOptions and as stand-alone argument");
+            }
+        }
         var command = CreateCommand("findOne").WithPayload(findOptions).AddCommandOptions(commandOptions);
         var response = await command.RunAsyncReturnDocumentData<DocumentResult<TResult>, TResult, FindStatusResult>(runSynchronously).ConfigureAwait(false);
         return response.Data.Document;

--- a/src/DataStax.AstraDB.DataApi/Core/Query/DocumentFindOptions.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/Query/DocumentFindOptions.cs
@@ -30,4 +30,14 @@ public class DocumentFindOptions<T> : FindOptions<T, CollectionSortBuilder<T>>
     [JsonIgnore]
     public override CollectionSortBuilder<T> Sort { get; set; }
 
+    internal DocumentFindOptions<T> Clone()
+    {
+        return new DocumentFindOptions<T>
+        {
+            Filter = Filter != null ? Filter.Clone() : null,
+            IncludeSimilarity = IncludeSimilarity,
+            Projection = Projection != null ? Projection.Clone() : null,
+            Sort = Sort != null ? Sort.Clone() : null
+        };
+    }
 }

--- a/src/DataStax.AstraDB.DataApi/Tables/Table.cs
+++ b/src/DataStax.AstraDB.DataApi/Tables/Table.cs
@@ -1133,9 +1133,15 @@ public class Table<T> : IQueryRunner<T, TableSortBuilder<T>> where T : class
         where TResult : class
     {
         findOptions = findOptions != null ? findOptions.Clone() : new TableFindOptions<T>();
-        if (findOptions.Filter == null && filter != null)
+        if (filter != null)
         {
-            findOptions.Filter = filter;
+            if (findOptions.Filter == null)
+            {
+                findOptions.Filter = filter;
+            } else
+            {
+                throw new ArgumentException("Cannot pass a filter both within FindOptions and as stand-alone argument");
+            }
         }
         commandOptions = SetRowSerializationOptions<TResult>(commandOptions, false);
         var command = CreateCommand("findOne").WithPayload(findOptions).AddCommandOptions(commandOptions);

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/TestObjects.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/TestObjects.cs
@@ -760,3 +760,10 @@ public class RowWithVector4
     [ColumnVector(4)]
     public float[] Vector { get; set; }
 }
+
+public class SimpleTwoColumnRow
+{
+    [ColumnPrimaryKey]
+    public int Id { get; set; }
+    public string Name { get; set; }
+}

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdditionalCollectionTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdditionalCollectionTests.cs
@@ -498,11 +498,14 @@ public class AdditionalCollectionTests
         var collectionName = "coll_findfiltertrick";
         try
         {
-            var collection = await fixture.Database.CreateCollectionAsync<SimpleObjectWithVector>(collectionName);
-            await collection.InsertManyAsync(new List<SimpleObjectWithVector> {
-                new SimpleObjectWithVector() { Id = 1, Name = "one" },
-                new SimpleObjectWithVector() { Id = 2, Name = "two" }
-            });
+            // TODO replace with:
+            // var collection = await fixture.Database.CreateCollectionAsync<SimpleObjectWithVector>(collectionName);
+            var collection = fixture.Database.GetCollection<SimpleObjectWithVector>(collectionName);
+            // TODO reinstate
+            // await collection.InsertManyAsync(new List<SimpleObjectWithVector> {
+            //     new SimpleObjectWithVector() { Id = 1, Name = "one" },
+            //     new SimpleObjectWithVector() { Id = 2, Name = "two" }
+            // });
 
             // find through filter
             
@@ -538,7 +541,8 @@ public class AdditionalCollectionTests
         }
         finally
         {
-            await fixture.Database.DropCollectionAsync(collectionName);
+            // TODO reinstate
+            // await fixture.Database.DropCollectionAsync(collectionName);
         }
     }
 

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdditionalCollectionTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdditionalCollectionTests.cs
@@ -492,6 +492,56 @@ public class AdditionalCollectionTests
         }
     }
 
+    [Fact]
+    public async Task Test_CollectionFindFilterTrick()
+    {
+        var collectionName = "coll_findfiltertrick";
+        try
+        {
+            var collection = await fixture.Database.CreateCollectionAsync<SimpleObjectWithVector>(collectionName);
+            await collection.InsertManyAsync(new List<SimpleObjectWithVector> {
+                new SimpleObjectWithVector() { Id = 1, Name = "one" },
+                new SimpleObjectWithVector() { Id = 2, Name = "two" }
+            });
+
+            // find through filter
+            
+            // find payload: {"findOne":{"filter":{"_id":{"$eq":1}}}}
+            var find_f_id1 = await collection.FindOneAsync(Builders<SimpleObjectWithVector>.CollectionFilter.Eq(d => d.Id, 1));
+            
+            // find payload: {"findOne":{"filter":{"_id":{"$eq":2}}}}
+            var find_f_id2 = await collection.FindOneAsync(Builders<SimpleObjectWithVector>.CollectionFilter.Eq(d => d.Id, 2));
+            
+            Assert.Equal("one", find_f_id1.Name);
+            Assert.Equal("two", find_f_id2.Name);
+
+            // find through findOptions
+            var findOpt_id1 = new DocumentFindOptions<SimpleObjectWithVector>()
+            {
+                Filter = Builders<SimpleObjectWithVector>.CollectionFilter.Eq(d => d.Id, 1)
+            };
+            var findOpt_id2 = new DocumentFindOptions<SimpleObjectWithVector>()
+            {
+                Filter = Builders<SimpleObjectWithVector>.CollectionFilter.Eq(d => d.Id, 2)
+            };
+            
+            // find payload: {"findOne":{}}
+            var find_o_id1 = await collection.FindOneAsync(findOpt_id1);
+            
+            // find payload: {"findOne":{}}
+            var find_o_id2 = await collection.FindOneAsync(findOpt_id2);
+            
+            // One of these two will fail! (because the payload silently drops the filter...)
+            Assert.Equal("one", find_o_id1.Name);
+            Assert.Equal("two", find_o_id2.Name);
+
+        }
+        finally
+        {
+            await fixture.Database.DropCollectionAsync(collectionName);
+        }
+    }
+
 }
 
 [CollectionName("testCollectionNameViaAttribute")]

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdditionalCollectionTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdditionalCollectionTests.cs
@@ -488,7 +488,7 @@ public class AdditionalCollectionTests
         }
         finally
         {
-            //await fixture.Database.DropCollectionAsync(collectionName);
+            await fixture.Database.DropCollectionAsync(collectionName);
         }
     }
 

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdditionalCollectionTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdditionalCollectionTests.cs
@@ -372,7 +372,6 @@ public class AdditionalCollectionTests
     }
 
     [Fact]
-<<<<<<< HEAD
     public async Task Test_VectorEncodingCollection_Typed()
     {
         // Note: full check of this test involves manual log inspection for the payloads.
@@ -494,10 +493,7 @@ public class AdditionalCollectionTests
     }
 
     [Fact]
-    public async Task Test_CollectionFindFilterTrick()
-=======
     public async Task Test_CollectionFindFilterSemantics()
->>>>>>> e9a447e (better findOptions testing and added guard to method)
     {
         var collectionName = "coll_findfiltersemantics";
         try

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdditionalCollectionTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdditionalCollectionTests.cs
@@ -499,7 +499,7 @@ public class AdditionalCollectionTests
     public async Task Test_CollectionFindFilterSemantics()
 >>>>>>> e9a447e (better findOptions testing and added guard to method)
     {
-        var collectionName = "coll_findfiltertrick";
+        var collectionName = "coll_findfiltersemantics";
         try
         {
             var collection = await fixture.Database.CreateCollectionAsync<SimpleObjectWithVector>(collectionName);
@@ -509,12 +509,13 @@ public class AdditionalCollectionTests
             });
 
             // 'naked' findOne:
+            // exp. payload: {"findOne":{}}
             var found_doc = await collection.FindOneAsync();
             Assert.NotNull(found_doc);
 
             // findOne through FILTER ONLY:
             //
-            // exp. ayload: {"findOne":{"filter":{"_id":{"$eq":1}}}}
+            // exp. payload: {"findOne":{"filter":{"_id":{"$eq":1}}}}
             var find_f_id1 = await collection.FindOneAsync(Builders<SimpleObjectWithVector>.CollectionFilter.Eq(d => d.Id, 1));
             // exp. payload: {"findOne":{"filter":{"_id":{"$eq":2}}}}
             var find_f_id2 = await collection.FindOneAsync(Builders<SimpleObjectWithVector>.CollectionFilter.Eq(d => d.Id, 2));

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdditionalCollectionTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdditionalCollectionTests.cs
@@ -372,6 +372,7 @@ public class AdditionalCollectionTests
     }
 
     [Fact]
+<<<<<<< HEAD
     public async Task Test_VectorEncodingCollection_Typed()
     {
         // Note: full check of this test involves manual log inspection for the payloads.
@@ -494,31 +495,34 @@ public class AdditionalCollectionTests
 
     [Fact]
     public async Task Test_CollectionFindFilterTrick()
+=======
+    public async Task Test_CollectionFindFilterSemantics()
+>>>>>>> e9a447e (better findOptions testing and added guard to method)
     {
         var collectionName = "coll_findfiltertrick";
         try
         {
-            // TODO replace with:
-            // var collection = await fixture.Database.CreateCollectionAsync<SimpleObjectWithVector>(collectionName);
-            var collection = fixture.Database.GetCollection<SimpleObjectWithVector>(collectionName);
-            // TODO reinstate
-            // await collection.InsertManyAsync(new List<SimpleObjectWithVector> {
-            //     new SimpleObjectWithVector() { Id = 1, Name = "one" },
-            //     new SimpleObjectWithVector() { Id = 2, Name = "two" }
-            // });
+            var collection = await fixture.Database.CreateCollectionAsync<SimpleObjectWithVector>(collectionName);
+            await collection.InsertManyAsync(new List<SimpleObjectWithVector> {
+                new SimpleObjectWithVector() { Id = 1, Name = "one" },
+                new SimpleObjectWithVector() { Id = 2, Name = "two" }
+            });
 
-            // find through filter
-            
-            // find payload: {"findOne":{"filter":{"_id":{"$eq":1}}}}
+            // 'naked' findOne:
+            var found_doc = await collection.FindOneAsync();
+            Assert.NotNull(found_doc);
+
+            // findOne through FILTER ONLY:
+            //
+            // exp. ayload: {"findOne":{"filter":{"_id":{"$eq":1}}}}
             var find_f_id1 = await collection.FindOneAsync(Builders<SimpleObjectWithVector>.CollectionFilter.Eq(d => d.Id, 1));
-            
-            // find payload: {"findOne":{"filter":{"_id":{"$eq":2}}}}
+            // exp. payload: {"findOne":{"filter":{"_id":{"$eq":2}}}}
             var find_f_id2 = await collection.FindOneAsync(Builders<SimpleObjectWithVector>.CollectionFilter.Eq(d => d.Id, 2));
-            
             Assert.Equal("one", find_f_id1.Name);
             Assert.Equal("two", find_f_id2.Name);
 
-            // find through findOptions
+            // findOne through FINDOPTIONS ONLY:
+            //
             var findOpt_id1 = new DocumentFindOptions<SimpleObjectWithVector>()
             {
                 Filter = Builders<SimpleObjectWithVector>.CollectionFilter.Eq(d => d.Id, 1)
@@ -527,22 +531,40 @@ public class AdditionalCollectionTests
             {
                 Filter = Builders<SimpleObjectWithVector>.CollectionFilter.Eq(d => d.Id, 2)
             };
-            
-            // find payload: {"findOne":{}}
+            // exp. payload: {"findOne":{"filter":{"_id":{"$eq":1}}}}
             var find_o_id1 = await collection.FindOneAsync(findOpt_id1);
-            
-            // find payload: {"findOne":{}}
+            // exp. payload: {"findOne":{"filter":{"_id":{"$eq":2}}}}
             var find_o_id2 = await collection.FindOneAsync(findOpt_id2);
-            
-            // One of these two will fail! (because the payload silently drops the filter...)
             Assert.Equal("one", find_o_id1.Name);
             Assert.Equal("two", find_o_id2.Name);
 
+            // findOne through BOTH FILTER AND FINDOPTIONS (should throw):
+            var findOpt_id991 = new DocumentFindOptions<SimpleObjectWithVector>()
+            {
+                Filter = Builders<SimpleObjectWithVector>.CollectionFilter.Eq(d => d.Id, 991)
+            };
+            var findOpt_id992 = new DocumentFindOptions<SimpleObjectWithVector>()
+            {
+                Filter = Builders<SimpleObjectWithVector>.CollectionFilter.Eq(d => d.Id, 992)
+            };
+            await Assert.ThrowsAsync<ArgumentException>(async () =>
+            {
+                await collection.FindOneAsync(
+                    Builders<SimpleObjectWithVector>.CollectionFilter.Eq(d => d.Id, 1),
+                    findOpt_id991
+                );
+            });
+            await Assert.ThrowsAsync<ArgumentException>(async () =>
+            {
+                await collection.FindOneAsync(
+                    Builders<SimpleObjectWithVector>.CollectionFilter.Eq(d => d.Id, 2),
+                    findOpt_id992
+                );
+            });
         }
         finally
         {
-            // TODO reinstate
-            // await fixture.Database.DropCollectionAsync(collectionName);
+            await fixture.Database.DropCollectionAsync(collectionName);
         }
     }
 

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdditionalTableTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdditionalTableTests.cs
@@ -1136,4 +1136,77 @@ public class AdditionalTableTests
         }
     }
 
+    [Fact]
+    public async Task Test_TableFindFilterSemantics()
+    {
+        var tableName = "table_findfiltersemantics";
+        try
+        {
+            var table = await fixture.Database.CreateTableAsync<SimpleTwoColumnRow>(tableName);
+            await table.InsertManyAsync(new List<SimpleTwoColumnRow> {
+                new SimpleTwoColumnRow() { Id = 1, Name = "one" },
+                new SimpleTwoColumnRow() { Id = 2, Name = "two" }
+            });
+
+            // 'naked' findOne:
+            // exp. payload: {"findOne":{}}
+            var found_row = await table.FindOneAsync();
+            Assert.NotNull(found_row);
+
+            // findOne through FILTER ONLY:
+            //
+            // exp. payload: {"findOne":{"filter":{"Id":{"$eq":1}}}}
+            var find_f_id1 = await table.FindOneAsync(Builders<SimpleTwoColumnRow>.TableFilter.Eq(d => d.Id, 1));
+            // exp. payload: {"findOne":{"filter":{"Id":{"$eq":2}}}}
+            var find_f_id2 = await table.FindOneAsync(Builders<SimpleTwoColumnRow>.TableFilter.Eq(d => d.Id, 2));
+            Assert.Equal("one", find_f_id1.Name);
+            Assert.Equal("two", find_f_id2.Name);
+
+            // findOne through FINDOPTIONS ONLY:
+            //
+            var findOpt_id1 = new TableFindOptions<SimpleTwoColumnRow>()
+            {
+                Filter = Builders<SimpleTwoColumnRow>.TableFilter.Eq(d => d.Id, 1)
+            };
+            var findOpt_id2 = new TableFindOptions<SimpleTwoColumnRow>()
+            {
+                Filter = Builders<SimpleTwoColumnRow>.TableFilter.Eq(d => d.Id, 2)
+            };
+            // exp. payload: {"findOne":{"filter":{"Id":{"$eq":1}}}}
+            var find_o_id1 = await table.FindOneAsync(findOpt_id1);
+            // exp. payload: {"findOne":{"filter":{"Id":{"$eq":2}}}}
+            var find_o_id2 = await table.FindOneAsync(findOpt_id2);
+            Assert.Equal("one", find_o_id1.Name);
+            Assert.Equal("two", find_o_id2.Name);
+
+            // findOne through BOTH FILTER AND FINDOPTIONS (should throw):
+            var findOpt_id991 = new TableFindOptions<SimpleTwoColumnRow>()
+            {
+                Filter = Builders<SimpleTwoColumnRow>.TableFilter.Eq(d => d.Id, 991)
+            };
+            var findOpt_id992 = new TableFindOptions<SimpleTwoColumnRow>()
+            {
+                Filter = Builders<SimpleTwoColumnRow>.TableFilter.Eq(d => d.Id, 992)
+            };
+            await Assert.ThrowsAsync<ArgumentException>(async () =>
+            {
+                await table.FindOneAsync(
+                    Builders<SimpleTwoColumnRow>.TableFilter.Eq(d => d.Id, 1),
+                    findOpt_id991
+                );
+            });
+            await Assert.ThrowsAsync<ArgumentException>(async () =>
+            {
+                await table.FindOneAsync(
+                    Builders<SimpleTwoColumnRow>.TableFilter.Eq(d => d.Id, 2),
+                    findOpt_id992
+                );
+            });
+        }
+        finally
+        {
+            await fixture.Database.DropTableAsync(tableName);
+        }
+    }
+
 }


### PR DESCRIPTION
This PR highlights issue #157 by adding tests that illustrate the problem with the current `FindOne` API, _and_ changes in the client to resolve the problem.

Closes #157 .
