### PR TITLE
Resolve all xmldoc warnings seen in the latest build for PR 118

### DIFF
--- a/src/DataStax.AstraDB.DataApi/Core/Enumeration/CollectionFindCursor.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/Enumeration/CollectionFindCursor.cs
@@ -25,7 +25,7 @@ namespace DataStax.AstraDB.DataApi.Core.Enumeration;
 /// </summary>
 /// <typeparam name="T">The type of the documents in the collection.</typeparam>
 /// <remarks>
-/// This cursor is returned by <see cref="Collection{T}.Find()"/> and provides a fluent API
+/// This cursor is returned by <see cref="Collections.Collection{T, Tid}.Find()"/> and provides a fluent API
 /// for filtering, sorting, limiting, and projecting documents. It supports both synchronous
 /// and asynchronous iteration patterns.
 /// </remarks>
@@ -62,7 +62,7 @@ public class CollectionFindCursor<T> : CollectionFindCursor<T, T> where T : clas
 /// <typeparam name="T">The type of the documents in the collection.</typeparam>
 /// <typeparam name="TResult">The type to deserialize the results to (e.g., when using projections).</typeparam>
 /// <remarks>
-/// This cursor is returned by <see cref="Collection{T}.Find{TResult}()"/> and provides a fluent API
+/// This cursor is returned by <see cref="Collection{T, TId}.Find{TResult}()"/> and provides a fluent API
 /// for filtering, sorting, limiting, and projecting documents into a different result type.
 /// </remarks>
 /// <example>

--- a/src/DataStax.AstraDB.DataApi/Core/Enumeration/CollectionFindCursor.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/Enumeration/CollectionFindCursor.cs
@@ -25,7 +25,7 @@ namespace DataStax.AstraDB.DataApi.Core.Enumeration;
 /// </summary>
 /// <typeparam name="T">The type of the documents in the collection.</typeparam>
 /// <remarks>
-/// This cursor is returned by <see cref="Collections.Collection{T, Tid}.Find()"/> and provides a fluent API
+/// This cursor is returned by <see cref="Collection{T, Tid}.Find()"/> and provides a fluent API
 /// for filtering, sorting, limiting, and projecting documents. It supports both synchronous
 /// and asynchronous iteration patterns.
 /// </remarks>

--- a/src/DataStax.AstraDB.DataApi/Core/Enumeration/FindCursor.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/Enumeration/FindCursor.cs
@@ -64,6 +64,7 @@ public class FindPage<T>
 /// <typeparam name="T">The type of records in the page.</typeparam>
 /// <typeparam name="TCursor">The type of the cursor.</typeparam>
 /// <param name="cursor">The cursor instance.</param>
+/// <param name="nextPageState">A pagination token (string) for the page to fetch. When provided it usually comes from the previous page response.</param>
 /// <param name="runSynchronously">Whether to run the operation synchronously.</param>
 /// <returns>A task that returns the fetched page.</returns>
 delegate Task<FindPage<T>> FetchPageFunc<T, in TCursor>(TCursor cursor, string nextPageState, bool runSynchronously);
@@ -78,7 +79,7 @@ delegate Task<FindPage<T>> FetchPageFunc<T, in TCursor>(TCursor cursor, string n
 /// </summary>
 /// <typeparam name="T">The type representing the record or row being queried.</typeparam>
 /// <typeparam name="TResult">The type to deserialize the results to (e.g., when using projections).</typeparam>
-/// <typeparam name="TSort">The type of sort builder to use (e.g., <see cref="DocumentSortBuilder{T}"/> or <see cref="TableSortBuilder{T}"/>).</typeparam>
+/// <typeparam name="TSort">The type of sort builder to use (e.g., <see cref="CollectionSortBuilder{T}"/> or <see cref="TableSortBuilder{T}"/>).</typeparam>
 /// <typeparam name="TCursor">The concrete cursor type for fluent method chaining.</typeparam>
 public abstract class FindCursor<T, TResult, TSort, TCursor> : AbstractCursor<TResult, TCursor>
     where T : class
@@ -228,7 +229,7 @@ public abstract class FindCursor<T, TResult, TSort, TCursor> : AbstractCursor<TR
     /// <param name="include">Whether to include the sort vector. Defaults to true.</param>
     /// <returns>A new cursor instance with the updated setting.</returns>
     /// <remarks>
-    /// When enabled, you can retrieve the sort vector using <see cref="GetSortVector"/> or <see cref="GetSortVectorAsync"/>.
+    /// When enabled, you can retrieve the sort vector using <see cref="GetSortVector()"/> or <see cref="GetSortVectorAsync(CancellationToken)"/>.
     /// This is useful for vector similarity searches where you want to access the vector used for sorting.
     /// </remarks>
     /// <example>

--- a/src/DataStax.AstraDB.DataApi/Core/Query/CollectionFindManyOptions.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/Query/CollectionFindManyOptions.cs
@@ -47,9 +47,11 @@ public class CollectionFindManyOptions<T> : IFindManyOptions<T, CollectionSortBu
     [JsonIgnore]
     public string InitialPageState { get => PageState; set => PageState = value; }
 
+    /// <summary>An optional amount of documents to skip in a find operation.</summary>
     [JsonIgnore]
     public int? Skip { get; set; }
 
+    /// <summary>An optional maximum number of documents to return in a find operation.</summary>
     [JsonIgnore]
     public int? Limit { get; set; }
 

--- a/src/DataStax.AstraDB.DataApi/Core/Query/DocumentFindManyOptions.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/Query/DocumentFindManyOptions.cs
@@ -37,7 +37,7 @@ internal class DocumentFindManyOptions<T> : DocumentFindOptions<T>, IFindManyOpt
 
     bool? IFindManyOptions<T, CollectionSortBuilder<T>>.IncludeSortVector { get => IncludeSortVector; set => IncludeSortVector = value; }
 
-    internal virtual DocumentFindOptions<T> Clone()
+    new internal virtual DocumentFindOptions<T> Clone()
     {
         return new DocumentFindManyOptions<T>
         {


### PR DESCRIPTION
It took me a ridiculous amount of time to figure out that `Collection{T}` must become `Collection{T, Tid}`.