### PR TITLE
Conflate CommandOptions into [Collection|Table]FindManyOptions for Find

### DIFF
--- a/src/DataStax.AstraDB.DataApi/Collections/Collection.cs
+++ b/src/DataStax.AstraDB.DataApi/Collections/Collection.cs
@@ -642,7 +642,7 @@ public class Collection<T, TId> where T : class
     /// </remarks>
     public CollectionFindCursor<T> Find()
     {
-        return Find(null, null);
+        return Find(null, null, null);
     }
 
     /// <inheritdoc cref="Find()" path="/summary"/>
@@ -657,14 +657,14 @@ public class Collection<T, TId> where T : class
     /// </example>
     public CollectionFindCursor<T> Find(CollectionFilter<T> filter)
     {
-        return Find(filter, null);
+        return Find(filter, null, null);
     }
 
     /// <inheritdoc cref="Find()" path="/summary"/>
     /// <param name="findOptions"></param>
     public CollectionFindCursor<T> Find(CollectionFindManyOptions<T> findOptions)
     {
-        return Find(null, findOptions);
+        return Find(null, findOptions, null);
     }
 
     /// <inheritdoc cref="Find(CollectionFilter{T})"/>
@@ -672,8 +672,17 @@ public class Collection<T, TId> where T : class
     /// <param name="findOptions"></param>
     public CollectionFindCursor<T> Find(CollectionFilter<T> filter, CollectionFindManyOptions<T> findOptions)
     {
+        return Find(filter, findOptions, null);
+    }
+
+    /// <inheritdoc cref="Find(CollectionFilter{T}, CollectionFindManyOptions{T})"/>
+    /// <param name="filter"></param>
+    /// <param name="findOptions"></param>
+    /// <param name="commandOptions"></param>
+    public CollectionFindCursor<T> Find(CollectionFilter<T> filter, CollectionFindManyOptions<T> findOptions, CommandOptions commandOptions)
+    {
         findOptions ??= new CollectionFindManyOptions<T>();
-        return new(findOptions.WithFilterParam(filter), null, RunFindManyAsync);
+        return new(findOptions.WithFilterParam(filter), commandOptions, RunFindManyAsync);
     }
 
     /// <inheritdoc cref="Find()" path="/summary"/>
@@ -683,7 +692,7 @@ public class Collection<T, TId> where T : class
     /// </remarks>
     public CollectionFindCursor<T, TResult> Find<TResult>() where TResult : class
     {
-        return Find<TResult>(null, null);
+        return Find<TResult>(null, null, null);
     }
 
     /// <inheritdoc cref="Find(CollectionFilter{T})"/>
@@ -693,7 +702,7 @@ public class Collection<T, TId> where T : class
     /// </remarks>
     public CollectionFindCursor<T, TResult> Find<TResult>(CollectionFilter<T> filter) where TResult : class
     {
-        return Find<TResult>(filter, null);
+        return Find<TResult>(filter, null, null);
     }
 
     /// <inheritdoc cref="Find(CollectionFindManyOptions{T})"/>
@@ -703,16 +712,28 @@ public class Collection<T, TId> where T : class
     /// </remarks>
     public CollectionFindCursor<T, TResult> Find<TResult>(CollectionFindManyOptions<T> findOptions) where TResult : class
     {
-        return Find<TResult>(null, findOptions);
+        return Find<TResult>(null, findOptions, null);
     }
 
-    /// <inheritdoc cref="Find{TResult}(CollectionFilter{T})"/>
-    /// <param name="filter"></param>
-    /// <param name="findOptions"></param>
+    /// <inheritdoc cref="Find(CollectionFilter{T}, CollectionFindManyOptions{T})"/>
+    /// <remarks>
+    /// The Find alternatives that accept a TResult type parameter allow for deserializing the document as a different type
+    /// (most commonly used when using projection to return a subset of fields)
+    /// </remarks>
     public CollectionFindCursor<T, TResult> Find<TResult>(CollectionFilter<T> filter, CollectionFindManyOptions<T> findOptions) where TResult : class
     {
+        return Find<TResult>(filter, findOptions, null);
+    }
+
+    /// <inheritdoc cref="Find(CollectionFilter{T}, CollectionFindManyOptions{T}, CommandOptions)"/>
+    /// <remarks>
+    /// The Find alternatives that accept a TResult type parameter allow for deserializing the document as a different type
+    /// (most commonly used when using projection to return a subset of fields)
+    /// </remarks>
+    public CollectionFindCursor<T, TResult> Find<TResult>(CollectionFilter<T> filter, CollectionFindManyOptions<T> findOptions, CommandOptions commandOptions) where TResult : class
+    {
         findOptions ??= new CollectionFindManyOptions<T>();
-        return new(findOptions.WithFilterParam(filter), null, RunFindManyAsync);
+        return new(findOptions.WithFilterParam(filter), commandOptions, RunFindManyAsync);
     }
 
     internal async Task<FindPage<TResult>> RunFindManyAsync<TResult>(CollectionFindCursor<T, TResult> cursor, string nextPageState, bool runSynchronously) where TResult : class

--- a/src/DataStax.AstraDB.DataApi/Collections/Collection.cs
+++ b/src/DataStax.AstraDB.DataApi/Collections/Collection.cs
@@ -642,7 +642,7 @@ public class Collection<T, TId> where T : class
     /// </remarks>
     public CollectionFindCursor<T> Find()
     {
-        return Find(null, null, null);
+        return Find(null, null);
     }
 
     /// <inheritdoc cref="Find()" path="/summary"/>
@@ -657,14 +657,14 @@ public class Collection<T, TId> where T : class
     /// </example>
     public CollectionFindCursor<T> Find(CollectionFilter<T> filter)
     {
-        return Find(filter, null, null);
+        return Find(filter, null);
     }
 
     /// <inheritdoc cref="Find()" path="/summary"/>
     /// <param name="findOptions"></param>
     public CollectionFindCursor<T> Find(CollectionFindManyOptions<T> findOptions)
     {
-        return Find(null, findOptions, null);
+        return Find(null, findOptions);
     }
 
     /// <inheritdoc cref="Find(CollectionFilter{T})"/>
@@ -672,16 +672,8 @@ public class Collection<T, TId> where T : class
     /// <param name="findOptions"></param>
     public CollectionFindCursor<T> Find(CollectionFilter<T> filter, CollectionFindManyOptions<T> findOptions)
     {
-        return Find(filter, findOptions, null);
-    }
-
-    /// <inheritdoc cref="Find(CollectionFilter{T}, CollectionFindManyOptions{T})"/>
-    /// <param name="filter"></param>
-    /// <param name="findOptions"></param>
-    /// <param name="commandOptions"></param>
-    public CollectionFindCursor<T> Find(CollectionFilter<T> filter, CollectionFindManyOptions<T> findOptions, CommandOptions commandOptions)
-    {
         findOptions ??= new CollectionFindManyOptions<T>();
+        var commandOptions = findOptions.commandOptions();
         return new(findOptions.WithFilterParam(filter), commandOptions, RunFindManyAsync);
     }
 
@@ -692,7 +684,7 @@ public class Collection<T, TId> where T : class
     /// </remarks>
     public CollectionFindCursor<T, TResult> Find<TResult>() where TResult : class
     {
-        return Find<TResult>(null, null, null);
+        return Find<TResult>(null, null);
     }
 
     /// <inheritdoc cref="Find(CollectionFilter{T})"/>
@@ -702,7 +694,7 @@ public class Collection<T, TId> where T : class
     /// </remarks>
     public CollectionFindCursor<T, TResult> Find<TResult>(CollectionFilter<T> filter) where TResult : class
     {
-        return Find<TResult>(filter, null, null);
+        return Find<TResult>(filter, null);
     }
 
     /// <inheritdoc cref="Find(CollectionFindManyOptions{T})"/>
@@ -712,7 +704,7 @@ public class Collection<T, TId> where T : class
     /// </remarks>
     public CollectionFindCursor<T, TResult> Find<TResult>(CollectionFindManyOptions<T> findOptions) where TResult : class
     {
-        return Find<TResult>(null, findOptions, null);
+        return Find<TResult>(null, findOptions);
     }
 
     /// <inheritdoc cref="Find(CollectionFilter{T}, CollectionFindManyOptions{T})"/>
@@ -722,17 +714,8 @@ public class Collection<T, TId> where T : class
     /// </remarks>
     public CollectionFindCursor<T, TResult> Find<TResult>(CollectionFilter<T> filter, CollectionFindManyOptions<T> findOptions) where TResult : class
     {
-        return Find<TResult>(filter, findOptions, null);
-    }
-
-    /// <inheritdoc cref="Find(CollectionFilter{T}, CollectionFindManyOptions{T}, CommandOptions)"/>
-    /// <remarks>
-    /// The Find alternatives that accept a TResult type parameter allow for deserializing the document as a different type
-    /// (most commonly used when using projection to return a subset of fields)
-    /// </remarks>
-    public CollectionFindCursor<T, TResult> Find<TResult>(CollectionFilter<T> filter, CollectionFindManyOptions<T> findOptions, CommandOptions commandOptions) where TResult : class
-    {
         findOptions ??= new CollectionFindManyOptions<T>();
+        var commandOptions = findOptions.commandOptions();
         return new(findOptions.WithFilterParam(filter), commandOptions, RunFindManyAsync);
     }
 
@@ -740,10 +723,11 @@ public class Collection<T, TId> where T : class
     {
         var options = cursor.FindOptions.Clone();
         options.PageState = nextPageState;
-        
-        var command = CreateCommand("find").WithPayload(options).AddCommandOptions(cursor.CommandOptions);
+
+        var payloadOptions = options.payloadOptions();
+        var command = CreateCommand("find").WithPayload(payloadOptions).AddCommandOptions(cursor.CommandOptions);
         var response = await command.RunAsyncReturnDocumentData<APIFindResult<TResult>, TResult, FindStatusResult>(runSynchronously).ConfigureAwait(false);
-        
+
         return new FindPage<TResult>(
             response.Data.NextPageState,
             response.Data.Items,

--- a/src/DataStax.AstraDB.DataApi/Collections/Collection.cs
+++ b/src/DataStax.AstraDB.DataApi/Collections/Collection.cs
@@ -673,7 +673,7 @@ public class Collection<T, TId> where T : class
     public CollectionFindCursor<T> Find(CollectionFilter<T> filter, CollectionFindManyOptions<T> findOptions)
     {
         findOptions ??= new CollectionFindManyOptions<T>();
-        var commandOptions = findOptions.commandOptions();
+        var commandOptions = findOptions.CommandOptions();
         return new(findOptions.WithFilterParam(filter), commandOptions, RunFindManyAsync);
     }
 
@@ -715,7 +715,7 @@ public class Collection<T, TId> where T : class
     public CollectionFindCursor<T, TResult> Find<TResult>(CollectionFilter<T> filter, CollectionFindManyOptions<T> findOptions) where TResult : class
     {
         findOptions ??= new CollectionFindManyOptions<T>();
-        var commandOptions = findOptions.commandOptions();
+        var commandOptions = findOptions.CommandOptions();
         return new(findOptions.WithFilterParam(filter), commandOptions, RunFindManyAsync);
     }
 

--- a/src/DataStax.AstraDB.DataApi/Collections/Collection.cs
+++ b/src/DataStax.AstraDB.DataApi/Collections/Collection.cs
@@ -724,7 +724,7 @@ public class Collection<T, TId> where T : class
         var options = cursor.FindOptions.Clone();
         options.PageState = nextPageState;
 
-        var payloadOptions = options.payloadOptions();
+        var payloadOptions = options.PayloadOptions();
         var command = CreateCommand("find").WithPayload(payloadOptions).AddCommandOptions(cursor.CommandOptions);
         var response = await command.RunAsyncReturnDocumentData<APIFindResult<TResult>, TResult, FindStatusResult>(runSynchronously).ConfigureAwait(false);
 

--- a/src/DataStax.AstraDB.DataApi/Collections/Collection.cs
+++ b/src/DataStax.AstraDB.DataApi/Collections/Collection.cs
@@ -134,39 +134,21 @@ public class Collection<T, TId> where T : class
     }
 
     /// <summary>
-    /// Synchronous version of <see cref="InsertManyAsync(List{T})"/>
+    /// Synchronous version of <see cref="InsertManyAsync(IEnumerable{T})"/>
     /// </summary>
-    /// <inheritdoc cref="InsertManyAsync(List{T})"/>
-    public CollectionInsertManyResult<TId> InsertMany(List<T> documents)
+    /// <inheritdoc cref="InsertManyAsync(IEnumerable{T})"/>
+    public CollectionInsertManyResult<TId> InsertMany(IEnumerable<T> documents)
     {
-        return InsertMany(documents, null, null);
+        return InsertMany(documents, null);
     }
 
     /// <summary>
-    /// Synchronous version of <see cref="InsertManyAsync(List{T}, InsertManyOptions)"/>
+    /// Synchronous version of <see cref="InsertManyAsync(IEnumerable{T}, InsertManyOptions)"/>
     /// </summary>
-    /// <inheritdoc cref="InsertManyAsync(List{T}, InsertManyOptions)"/>
-    public CollectionInsertManyResult<TId> InsertMany(List<T> documents, InsertManyOptions insertOptions)
+    /// <inheritdoc cref="InsertManyAsync(IEnumerable{T}, InsertManyOptions)"/>
+    public CollectionInsertManyResult<TId> InsertMany(IEnumerable<T> documents, InsertManyOptions insertOptions)
     {
-        return InsertMany(documents, insertOptions, null);
-    }
-
-    /// <summary>
-    /// Synchronous version of <see cref="InsertManyAsync(List{T}, CommandOptions)"/>
-    /// </summary>
-    /// <inheritdoc cref="InsertManyAsync(List{T}, CommandOptions)"/>
-    public CollectionInsertManyResult<TId> InsertMany(List<T> documents, CommandOptions commandOptions)
-    {
-        return InsertMany(documents, null, commandOptions);
-    }
-
-    /// <summary>
-    /// Synchronous version of <see cref="InsertManyAsync(List{T}, InsertManyOptions, CommandOptions)"/>
-    /// </summary>
-    /// <inheritdoc cref="InsertManyAsync(List{T}, InsertManyOptions, CommandOptions)"/>
-    public CollectionInsertManyResult<TId> InsertMany(List<T> documents, InsertManyOptions insertOptions, CommandOptions commandOptions)
-    {
-        return InsertManyAsync(documents, insertOptions, commandOptions, runSynchronously: true).ResultSync();
+        return InsertManyAsync(documents, insertOptions, runSynchronously: true).ResultSync();
     }
 
     /// <summary>
@@ -174,44 +156,30 @@ public class Collection<T, TId> where T : class
     /// </summary>
     /// <param name="documents">The list of documents to insert.</param>
     /// <returns></returns>
-    /// <throws cref="ArgumentException">Thrown if the documents list is null or empty.</throws>
-    /// <throws cref="BulkOperationException{T}">Thrown if an error occurs during the bulk operation, 
+    /// <remarks>
+    /// If you need to control concurrency, chunk size, whether the insert is ordered or not, or other options, use the <see cref="InsertManyAsync(IEnumerable{T}, InsertManyOptions)"/> overload.
+    /// </remarks>
+    /// <throws cref="BulkOperationException{T}">Thrown if an error occurs during the bulk operation,
     /// with partial results returned in the <see cref="BulkOperationException{T}.PartialResult"/> property.</throws>
-    public Task<CollectionInsertManyResult<TId>> InsertManyAsync(List<T> documents)
+    public Task<CollectionInsertManyResult<TId>> InsertManyAsync(IEnumerable<T> documents)
     {
-        return InsertManyAsync(documents, new CommandOptions());
+        return InsertManyAsync(documents, null);
     }
 
-    /// <inheritdoc cref="InsertManyAsync(List{T})"/>
-    /// <param name="documents"></param>
-    /// <param name="insertOptions">Allows specifying whether the documents should be inserted in order as well as the chunk size.</param>
-    public Task<CollectionInsertManyResult<TId>> InsertManyAsync(List<T> documents, InsertManyOptions insertOptions)
+    /// <inheritdoc cref="InsertManyAsync(IEnumerable{T})"/>
+    /// <param name="documents">The list of documents to insert.</param>
+    /// <param name="insertOptions">Allows specifying the insertion chunk size, ordered/unordered mode, concurrency, as well as other generic command-execution options.</param>
+    public Task<CollectionInsertManyResult<TId>> InsertManyAsync(IEnumerable<T> documents, InsertManyOptions insertOptions)
     {
-        return InsertManyAsync(documents, insertOptions, null, runSynchronously: false);
+        return InsertManyAsync(documents, insertOptions, runSynchronously: false);
     }
 
-    /// <inheritdoc cref="InsertManyAsync(List{T})"/>
-    /// <param name="documents"></param>
-    /// <param name="commandOptions"></param>
-    public Task<CollectionInsertManyResult<TId>> InsertManyAsync(List<T> documents, CommandOptions commandOptions)
+    private async Task<CollectionInsertManyResult<TId>> InsertManyAsync(IEnumerable<T> documents, InsertManyOptions insertOptions, bool runSynchronously)
     {
-        return InsertManyAsync(documents, null, commandOptions, runSynchronously: false);
-    }
-
-    /// <inheritdoc cref="InsertManyAsync(List{T}, InsertManyOptions)"/>
-    /// <param name="documents"></param>
-    /// <param name="insertOptions"></param>
-    /// <param name="commandOptions"></param>
-    public Task<CollectionInsertManyResult<TId>> InsertManyAsync(List<T> documents, InsertManyOptions insertOptions, CommandOptions commandOptions)
-    {
-        return InsertManyAsync(documents, insertOptions, commandOptions, runSynchronously: false);
-    }
-
-    private async Task<CollectionInsertManyResult<TId>> InsertManyAsync(List<T> documents, InsertManyOptions insertOptions, CommandOptions commandOptions, bool runSynchronously)
-    {
-        Guard.NotNullOrEmpty(documents, nameof(documents));
+        Guard.NotNull(documents, nameof(documents));
 
         if (insertOptions == null) insertOptions = new InsertManyOptions();
+        var commandOptions = insertOptions.CommandOptions();
         if (insertOptions.Concurrency > 1 && insertOptions.Ordered)
         {
             throw new ArgumentException("Cannot run ordered insert_many concurrently.");

--- a/src/DataStax.AstraDB.DataApi/Core/CommandOptions.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/CommandOptions.cs
@@ -48,6 +48,7 @@ public class CommandOptions
     /// <summary>
     /// The token to use for authentication
     /// </summary>
+    [JsonIgnore]
     public string Token { get; set; }
     
     /// <summary>
@@ -55,6 +56,7 @@ public class CommandOptions
     /// 
     /// Defaults to <see cref="Core.RunMode.Normal"/>
     /// </summary>
+    [JsonIgnore]
     public RunMode? RunMode { get; set; }
     
     /// <summary>
@@ -62,6 +64,7 @@ public class CommandOptions
     /// 
     /// Defaults to <see cref="DataAPIDestination.ASTRA"/>
     /// </summary>
+    [JsonIgnore]
     public DataAPIDestination? Destination { get; set; }
 
     /// <summary>
@@ -69,6 +72,7 @@ public class CommandOptions
     /// 
     /// Defaults to HttpVersion: 2.0, FollowRedirects: true
     /// </summary>
+    [JsonIgnore]
     public HttpClientOptions HttpClientOptions { get; set; }
 
     /// <summary>
@@ -77,6 +81,7 @@ public class CommandOptions
     /// <remarks>
     /// See <see cref="TimeoutOptions"/> for information.
     /// </remarks>
+    [JsonIgnore]
     public TimeoutOptions TimeoutOptions { get; set; } = new TimeoutOptions();
 
     /// <summary>
@@ -84,6 +89,7 @@ public class CommandOptions
     /// 
     /// Defaults to <see cref="APIVersion.V1"/>
     /// </summary>
+    [JsonIgnore]
     public APIVersion? APIVersion { get; set; }
 
     internal string APIUrlBase
@@ -101,6 +107,7 @@ public class CommandOptions
     /// <summary>
     /// An optional CancellationToken to interrupt asynchronous operations
     /// </summary>
+    [JsonIgnore]
     public CancellationToken? CancellationToken { get; set; }
 
     internal CancellationToken? BulkOperationCancellationToken { get; set; }

--- a/src/DataStax.AstraDB.DataApi/Core/HttpClientOptions.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/HttpClientOptions.cs
@@ -32,4 +32,14 @@ public class HttpClientOptions
     /// Whether the HTTP client should follow redirects or not.
     /// </summary>
     public bool FollowRedirects { get; set; } = true;
+
+    internal HttpClientOptions Clone()
+    {
+        return new HttpClientOptions
+        {
+            HttpVersion = HttpVersion,
+            FollowRedirects = FollowRedirects,
+        };
+    }
+
 }

--- a/src/DataStax.AstraDB.DataApi/Core/InsertManyOptions.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/InsertManyOptions.cs
@@ -19,7 +19,7 @@ namespace DataStax.AstraDB.DataApi.Core;
 /// <summary>
 /// Options for inserting multiple documents into a collection.
 /// </summary>
-public class InsertManyOptions
+public class InsertManyOptions : CommandOptions
 {
     /// <summary>
     /// Default batch size.
@@ -54,4 +54,36 @@ public class InsertManyOptions
     /// The number of documents to insert in each batch.
     /// </summary>
     public int ChunkSize { get; set; } = DefaultChunkSize;
+
+    internal CommandOptions CommandOptions()
+    {
+        return new CommandOptions {
+            Token = Token,
+            RunMode = RunMode,
+            Destination = Destination,
+            HttpClientOptions = HttpClientOptions != null ? HttpClientOptions.Clone() : null,
+            TimeoutOptions = TimeoutOptions != null ? TimeoutOptions.Clone() : null,
+            APIVersion = APIVersion,
+            CancellationToken = CancellationToken
+        };
+    }
+
+    internal InsertManyOptions Clone()
+    {
+        return new InsertManyOptions
+        {
+            Ordered = Ordered,
+            Concurrency = Concurrency,
+            ChunkSize = ChunkSize,
+            // CommandOptions properties:
+            Token = Token,
+            RunMode = RunMode,
+            Destination = Destination,
+            HttpClientOptions = HttpClientOptions != null ? HttpClientOptions.Clone() : null,
+            TimeoutOptions = TimeoutOptions != null ? TimeoutOptions.Clone() : null,
+            APIVersion = APIVersion,
+            CancellationToken = CancellationToken
+        };
+    }
+
 }

--- a/src/DataStax.AstraDB.DataApi/Core/InsertManyOptions.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/InsertManyOptions.cs
@@ -24,12 +24,12 @@ public class InsertManyOptions
     /// <summary>
     /// Default batch size.
     /// </summary>
-    public const int DefaultChunkSize = 100;
+    public const int DefaultChunkSize = 50;
 
     /// <summary>
-    /// Maximum concurrency.
+    /// Default concurrency for unordered insertions.
     /// </summary>
-    public const int MaxConcurrency = int.MaxValue;
+    public const int DefaultConcurrency = 20;
 
     private bool _Ordered = false;
     /// <summary>
@@ -48,7 +48,7 @@ public class InsertManyOptions
     /// The number of parallel processes to use while inserting documents.
     /// Must be set to 1 for ordered inserts.
     /// </summary>
-    public int Concurrency { get; set; } = MaxConcurrency;
+    public int Concurrency { get; set; } = DefaultConcurrency;
 
     /// <summary>
     /// The number of documents to insert in each batch.

--- a/src/DataStax.AstraDB.DataApi/Core/Query/CollectionFindManyOptions.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/Query/CollectionFindManyOptions.cs
@@ -25,7 +25,7 @@ namespace DataStax.AstraDB.DataApi.Core.Query;
 /// Options for finding multiple documents in a collection.
 /// </summary>
 /// <typeparam name="T">The type of the document.</typeparam>
-public class CollectionFindManyOptions<T> : IFindManyOptions<T, CollectionSortBuilder<T>>
+public class CollectionFindManyOptions<T> : CommandOptions, IFindManyOptions<T, CollectionSortBuilder<T>>
 {
     /// <summary>The projection to apply to the results.</summary>
     [JsonIgnore]
@@ -114,6 +114,33 @@ public class CollectionFindManyOptions<T> : IFindManyOptions<T, CollectionSortBu
         }
     }
 
+    IFindManyOptions<T, CollectionSortBuilder<T>> IFindManyOptions<T, CollectionSortBuilder<T>>.payloadOptions()
+    {
+        return new CollectionFindManyOptions<T> {
+            Filter = Filter,
+            InitialPageState = InitialPageState,
+            Skip = Skip,
+            Limit = Limit,
+            IncludeSortVector = IncludeSortVector,
+            IncludeSimilarity = IncludeSimilarity,
+            Projection = Projection != null ? Projection.Clone() : null,
+            Sort = Sort != null ? Sort.Clone() : null,
+        };
+    }
+
+    internal CommandOptions commandOptions()
+    {
+        return new CommandOptions {
+            Token = Token,
+            RunMode = RunMode,
+            Destination = Destination,
+            HttpClientOptions = HttpClientOptions != null ? HttpClientOptions.Clone() : null,
+            TimeoutOptions = TimeoutOptions != null ? TimeoutOptions.Clone() : null,
+            ApiVersion = ApiVersion,
+            CancellationToken = CancellationToken
+        };
+    }
+
     internal CollectionFindManyOptions<T> Clone()
     {
         return new CollectionFindManyOptions<T>
@@ -125,7 +152,15 @@ public class CollectionFindManyOptions<T> : IFindManyOptions<T, CollectionSortBu
             IncludeSortVector = IncludeSortVector,
             IncludeSimilarity = IncludeSimilarity,
             Projection = Projection != null ? Projection.Clone() : null,
-            Sort = Sort != null ? Sort.Clone() : null
+            Sort = Sort != null ? Sort.Clone() : null,
+            // CommandOptions properties:
+            Token = Token,
+            RunMode = RunMode,
+            Destination = Destination,
+            HttpClientOptions = HttpClientOptions != null ? HttpClientOptions.Clone() : null,
+            TimeoutOptions = TimeoutOptions != null ? TimeoutOptions.Clone() : null,
+            ApiVersion = ApiVersion,
+            CancellationToken = CancellationToken
         };
     }
 

--- a/src/DataStax.AstraDB.DataApi/Core/Query/CollectionFindManyOptions.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/Query/CollectionFindManyOptions.cs
@@ -136,7 +136,7 @@ public class CollectionFindManyOptions<T> : CommandOptions, IFindManyOptions<T, 
             Destination = Destination,
             HttpClientOptions = HttpClientOptions != null ? HttpClientOptions.Clone() : null,
             TimeoutOptions = TimeoutOptions != null ? TimeoutOptions.Clone() : null,
-            ApiVersion = ApiVersion,
+            APIVersion = APIVersion,
             CancellationToken = CancellationToken
         };
     }
@@ -159,7 +159,7 @@ public class CollectionFindManyOptions<T> : CommandOptions, IFindManyOptions<T, 
             Destination = Destination,
             HttpClientOptions = HttpClientOptions != null ? HttpClientOptions.Clone() : null,
             TimeoutOptions = TimeoutOptions != null ? TimeoutOptions.Clone() : null,
-            ApiVersion = ApiVersion,
+            APIVersion = APIVersion,
             CancellationToken = CancellationToken
         };
     }

--- a/src/DataStax.AstraDB.DataApi/Core/Query/CollectionFindManyOptions.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/Query/CollectionFindManyOptions.cs
@@ -128,7 +128,7 @@ public class CollectionFindManyOptions<T> : CommandOptions, IFindManyOptions<T, 
         };
     }
 
-    internal CommandOptions commandOptions()
+    internal CommandOptions CommandOptions()
     {
         return new CommandOptions {
             Token = Token,

--- a/src/DataStax.AstraDB.DataApi/Core/Query/CollectionFindManyOptions.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/Query/CollectionFindManyOptions.cs
@@ -114,7 +114,7 @@ public class CollectionFindManyOptions<T> : CommandOptions, IFindManyOptions<T, 
         }
     }
 
-    IFindManyOptions<T, CollectionSortBuilder<T>> IFindManyOptions<T, CollectionSortBuilder<T>>.payloadOptions()
+    IFindManyOptions<T, CollectionSortBuilder<T>> IFindManyOptions<T, CollectionSortBuilder<T>>.PayloadOptions()
     {
         return new CollectionFindManyOptions<T> {
             Filter = Filter,

--- a/src/DataStax.AstraDB.DataApi/Core/Query/CollectionFindManyOptions.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/Query/CollectionFindManyOptions.cs
@@ -55,14 +55,16 @@ public class CollectionFindManyOptions<T> : CommandOptions, IFindManyOptions<T, 
     [JsonIgnore]
     public int? Limit { get; set; }
 
+    /// <summary>
+    /// Whether to include the sort vector in the result or not
+    /// </summary>
     [JsonIgnore]
-    internal bool? IncludeSortVector { get; set; }
+    public bool? IncludeSortVector { get; set; }
 
     bool? IFindManyOptions<T, CollectionSortBuilder<T>>.IncludeSortVector { get => IncludeSortVector; set => IncludeSortVector = value; }
 
     internal Filter<T> Filter { get; set; }
 
-    [JsonIgnore]
     internal string PageState { get; set; }
 
     string IFindOptions<T, CollectionSortBuilder<T>>.PageState { get => PageState; set => PageState = value; }

--- a/src/DataStax.AstraDB.DataApi/Core/Query/IFindManyOptions.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/Query/IFindManyOptions.cs
@@ -40,4 +40,6 @@ internal interface IFindManyOptions<T, TSort> : IFindOptions<T, TSort>
     internal bool? IncludeSortVector { get; set; }
 
     internal IFindManyOptions<T, TSort> Clone();
+
+    internal IFindManyOptions<T, TSort> payloadOptions();
 }

--- a/src/DataStax.AstraDB.DataApi/Core/Query/IFindManyOptions.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/Query/IFindManyOptions.cs
@@ -41,5 +41,5 @@ internal interface IFindManyOptions<T, TSort> : IFindOptions<T, TSort>
 
     internal IFindManyOptions<T, TSort> Clone();
 
-    internal IFindManyOptions<T, TSort> payloadOptions();
+    internal IFindManyOptions<T, TSort> PayloadOptions();
 }

--- a/src/DataStax.AstraDB.DataApi/Core/Query/TableFindManyOptions.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/Query/TableFindManyOptions.cs
@@ -25,7 +25,7 @@ namespace DataStax.AstraDB.DataApi.Core.Query;
 /// A set of options to be used when finding rows in a table.
 /// </summary>
 /// <typeparam name="T"></typeparam>
-public class TableFindManyOptions<T> : IFindManyOptions<T, TableSortBuilder<T>>
+public class TableFindManyOptions<T> : CommandOptions, IFindManyOptions<T, TableSortBuilder<T>>
 {
     /// <summary>The projection to apply to the results.</summary>
     [JsonIgnore]
@@ -144,6 +144,33 @@ public class TableFindManyOptions<T> : IFindManyOptions<T, TableSortBuilder<T>>
         }
     }
 
+    IFindManyOptions<T, TableSortBuilder<T>> IFindManyOptions<T, TableSortBuilder<T>>.payloadOptions()
+    {
+        return new TableFindManyOptions<T> {
+            Filter = Filter,
+            InitialPageState = InitialPageState,
+            Skip = Skip,
+            Limit = Limit,
+            IncludeSortVector = IncludeSortVector,
+            IncludeSimilarity = IncludeSimilarity,
+            Projection = Projection != null ? Projection.Clone() : null,
+            Sort = Sort != null ? Sort.Clone() : null,
+        };
+    }
+
+    internal CommandOptions commandOptions()
+    {
+        return new CommandOptions {
+            Token = Token,
+            RunMode = RunMode,
+            Destination = Destination,
+            HttpClientOptions = HttpClientOptions != null ? HttpClientOptions.Clone() : null,
+            TimeoutOptions = TimeoutOptions != null ? TimeoutOptions.Clone() : null,
+            ApiVersion = ApiVersion,
+            CancellationToken = CancellationToken
+        };
+    }
+
     internal TableFindManyOptions<T> Clone()
     {
         return new TableFindManyOptions<T>
@@ -155,50 +182,37 @@ public class TableFindManyOptions<T> : IFindManyOptions<T, TableSortBuilder<T>>
             IncludeSortVector = IncludeSortVector,
             IncludeSimilarity = IncludeSimilarity,
             Projection = Projection != null ? Projection.Clone() : null,
-            Sort = Sort != null ? Sort.Clone() : null
+            Sort = Sort != null ? Sort.Clone() : null,
+            // CommandOptions properties:
+            Token = Token,
+            RunMode = RunMode,
+            Destination = Destination,
+            HttpClientOptions = HttpClientOptions != null ? HttpClientOptions.Clone() : null,
+            TimeoutOptions = TimeoutOptions != null ? TimeoutOptions.Clone() : null,
+            ApiVersion = ApiVersion,
+            CancellationToken = CancellationToken
         };
     }
 
-        IFindManyOptions<T, TableSortBuilder<T>> IFindManyOptions<T, TableSortBuilder<T>>.Clone()
-
-        {
-
-            return Clone();
-
-        }
-
-    
-
-        internal TableFindManyOptions<T> WithFilterParam(TableFilter<T> filter)
-
-        {
-
-            if (filter == null)
-
-            {
-
-                return this;
-
-            }
-
-            
-
-            if (Filter != null)
-
-            {
-
-                throw new ArgumentException("Cannot pass a filter both within FindOptions and as stand-alone argument");
-
-            }
-
-            
-
-            var cloned = Clone();
-
-            cloned.Filter = filter;
-
-            return cloned;
-
-        }
-
+    IFindManyOptions<T, TableSortBuilder<T>> IFindManyOptions<T, TableSortBuilder<T>>.Clone()
+    {
+        return Clone();
     }
+
+    internal TableFindManyOptions<T> WithFilterParam(TableFilter<T> filter)
+    {
+        if (filter == null)
+        {
+            return this;
+        }
+
+        if (Filter != null)
+        {
+            throw new ArgumentException("Cannot pass a filter both within FindOptions and as stand-alone argument");
+        }
+
+        var cloned = Clone();
+        cloned.Filter = filter;
+        return cloned;
+    }
+}

--- a/src/DataStax.AstraDB.DataApi/Core/Query/TableFindManyOptions.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/Query/TableFindManyOptions.cs
@@ -166,7 +166,7 @@ public class TableFindManyOptions<T> : CommandOptions, IFindManyOptions<T, Table
             Destination = Destination,
             HttpClientOptions = HttpClientOptions != null ? HttpClientOptions.Clone() : null,
             TimeoutOptions = TimeoutOptions != null ? TimeoutOptions.Clone() : null,
-            ApiVersion = ApiVersion,
+            APIVersion = APIVersion,
             CancellationToken = CancellationToken
         };
     }
@@ -189,7 +189,7 @@ public class TableFindManyOptions<T> : CommandOptions, IFindManyOptions<T, Table
             Destination = Destination,
             HttpClientOptions = HttpClientOptions != null ? HttpClientOptions.Clone() : null,
             TimeoutOptions = TimeoutOptions != null ? TimeoutOptions.Clone() : null,
-            ApiVersion = ApiVersion,
+            APIVersion = APIVersion,
             CancellationToken = CancellationToken
         };
     }

--- a/src/DataStax.AstraDB.DataApi/Core/Query/TableFindManyOptions.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/Query/TableFindManyOptions.cs
@@ -158,7 +158,7 @@ public class TableFindManyOptions<T> : CommandOptions, IFindManyOptions<T, Table
         };
     }
 
-    internal CommandOptions commandOptions()
+    internal CommandOptions CommandOptions()
     {
         return new CommandOptions {
             Token = Token,

--- a/src/DataStax.AstraDB.DataApi/Core/Query/TableFindManyOptions.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/Query/TableFindManyOptions.cs
@@ -144,7 +144,7 @@ public class TableFindManyOptions<T> : CommandOptions, IFindManyOptions<T, Table
         }
     }
 
-    IFindManyOptions<T, TableSortBuilder<T>> IFindManyOptions<T, TableSortBuilder<T>>.payloadOptions()
+    IFindManyOptions<T, TableSortBuilder<T>> IFindManyOptions<T, TableSortBuilder<T>>.PayloadOptions()
     {
         return new TableFindManyOptions<T> {
             Filter = Filter,

--- a/src/DataStax.AstraDB.DataApi/Core/Query/TableFindManyOptions.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/Query/TableFindManyOptions.cs
@@ -86,7 +86,7 @@ public class TableFindManyOptions<T> : CommandOptions, IFindManyOptions<T, Table
     /// </code>
     /// </example>
     [JsonIgnore]
-    internal bool? IncludeSortVector { get; set; }
+    public bool? IncludeSortVector { get; set; }
 
     bool? IFindManyOptions<T, TableSortBuilder<T>>.IncludeSortVector { get => IncludeSortVector; set => IncludeSortVector = value; }
 

--- a/src/DataStax.AstraDB.DataApi/Core/TimeoutOptions.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/TimeoutOptions.cs
@@ -94,4 +94,18 @@ public class TimeoutOptions
     /// The timeout for keyspace administration operations, such as creating or deleting keyspaces.
     /// </summary>
     public TimeSpan? KeyspaceAdminTimeout { get; set; }
+
+    internal TimeoutOptions Clone()
+    {
+        return new TimeoutOptions
+        {
+            ConnectionTimeout = ConnectionTimeout,
+            RequestTimeout = RequestTimeout,
+            BulkOperationTimeout = BulkOperationTimeout,
+            CollectionAdminTimeout = CollectionAdminTimeout,
+            TableAdminTimeout = TableAdminTimeout,
+            DatabaseAdminTimeout = DatabaseAdminTimeout,
+            KeyspaceAdminTimeout = KeyspaceAdminTimeout,
+        };
+    }
 }

--- a/src/DataStax.AstraDB.DataApi/Tables/Table.cs
+++ b/src/DataStax.AstraDB.DataApi/Tables/Table.cs
@@ -916,7 +916,7 @@ public class Table<T> where T : class
     public TableFindCursor<T> Find(TableFilter<T> filter, TableFindManyOptions<T> findOptions)
     {
         findOptions ??= new TableFindManyOptions<T>();
-        var commandOptions = findOptions.commandOptions();
+        var commandOptions = findOptions.CommandOptions();
         return new(findOptions.WithFilterParam(filter), commandOptions, RunFindManyAsync);
     }
 
@@ -958,7 +958,7 @@ public class Table<T> where T : class
     public TableFindCursor<T, TResult> Find<TResult>(TableFilter<T> filter, TableFindManyOptions<T> findOptions) where TResult : class
     {
         findOptions ??= new TableFindManyOptions<T>();
-        var commandOptions = findOptions.commandOptions();
+        var commandOptions = findOptions.CommandOptions();
         return new(findOptions.WithFilterParam(filter), commandOptions, RunFindManyAsync);
     }
 

--- a/src/DataStax.AstraDB.DataApi/Tables/Table.cs
+++ b/src/DataStax.AstraDB.DataApi/Tables/Table.cs
@@ -881,7 +881,7 @@ public class Table<T> where T : class
     /// </remarks>
     public TableFindCursor<T> Find()
     {
-        return Find(null, null, null);
+        return Find(null, null);
     }
 
     /// <inheritdoc cref="Find()"/>
@@ -900,14 +900,14 @@ public class Table<T> where T : class
     /// </example>
     public TableFindCursor<T> Find(TableFilter<T> filter)
     {
-        return Find(filter, null, null);
+        return Find(filter, null);
     }
 
     /// <inheritdoc cref="Find()" path="/summary"/>
     /// <param name="findOptions"></param>
     public TableFindCursor<T> Find(TableFindManyOptions<T> findOptions)
     {
-        return Find(null, findOptions, null);
+        return Find(null, findOptions);
     }
 
     /// <inheritdoc cref="Find(TableFilter{T})"/>
@@ -916,16 +916,7 @@ public class Table<T> where T : class
     public TableFindCursor<T> Find(TableFilter<T> filter, TableFindManyOptions<T> findOptions)
     {
         findOptions ??= new TableFindManyOptions<T>();
-        return Find(filter, findOptions, null);
-    }
-
-    /// <inheritdoc cref="Find(TableFilter{T}, TableFindManyOptions{T})"/>
-    /// <param name="filter"></param>
-    /// <param name="findOptions"></param>
-    /// <param name="commandOptions"></param>
-    public TableFindCursor<T> Find(TableFilter<T> filter, TableFindManyOptions<T> findOptions, CommandOptions commandOptions)
-    {
-        findOptions ??= new TableFindManyOptions<T>();
+        var commandOptions = findOptions.commandOptions();
         return new(findOptions.WithFilterParam(filter), commandOptions, RunFindManyAsync);
     }
 
@@ -936,7 +927,7 @@ public class Table<T> where T : class
     /// </remarks>
     public TableFindCursor<T, TResult> Find<TResult>() where TResult : class
     {
-        return Find<TResult>(null, null, null);
+        return Find<TResult>(null, null);
     }
 
     /// <inheritdoc cref="Find(TableFilter{T})"/>
@@ -946,7 +937,7 @@ public class Table<T> where T : class
     /// </remarks>
     public TableFindCursor<T, TResult> Find<TResult>(TableFilter<T> filter) where TResult : class
     {
-        return Find<TResult>(filter, null, null);
+        return Find<TResult>(filter, null);
     }
 
     /// <inheritdoc cref="Find(TableFindManyOptions{T})"/>
@@ -956,7 +947,7 @@ public class Table<T> where T : class
     /// </remarks>
     public TableFindCursor<T, TResult> Find<TResult>(TableFindManyOptions<T> findOptions) where TResult : class
     {
-        return Find<TResult>(null, findOptions, null);
+        return Find<TResult>(null, findOptions);
     }
 
     /// <inheritdoc cref="Find(TableFilter{T}, TableFindManyOptions{T})"/>
@@ -966,17 +957,8 @@ public class Table<T> where T : class
     /// </remarks>
     public TableFindCursor<T, TResult> Find<TResult>(TableFilter<T> filter, TableFindManyOptions<T> findOptions) where TResult : class
     {
-        return Find<TResult>(filter, findOptions, null);
-    }
-
-    /// <inheritdoc cref="Find(TableFilter{T}, TableFindManyOptions{T}, CommandOptions)"/>
-    /// <remarks>
-    /// The Find alternatives that accept a TResult type parameter allow for deserializing the row as a different type
-    /// (most commonly used when using projection to return a subset of fields)
-    /// </remarks>
-    public TableFindCursor<T, TResult> Find<TResult>(TableFilter<T> filter, TableFindManyOptions<T> findOptions, CommandOptions commandOptions) where TResult : class
-    {
         findOptions ??= new TableFindManyOptions<T>();
+        var commandOptions = findOptions.commandOptions();
         return new(findOptions.WithFilterParam(filter), commandOptions, RunFindManyAsync);
     }
 
@@ -984,9 +966,10 @@ public class Table<T> where T : class
     {
         var options = cursor.FindOptions.Clone();
         options.PageState = nextPageState;
-        
+
+        var payloadOptions = options.payloadOptions();
         var commandOptions = SetRowSerializationOptions<TResult>(cursor.CommandOptions, false);
-        var command = CreateCommand("find").WithPayload(options).AddCommandOptions(commandOptions);
+        var command = CreateCommand("find").WithPayload(payloadOptions).AddCommandOptions(commandOptions);
         var response = await command.RunAsyncReturnData<APIFindResult<TResult>, TableFindStatusResult>(runSynchronously).ConfigureAwait(false);
         
         if (typeof(Row).IsAssignableFrom(typeof(TResult)))

--- a/src/DataStax.AstraDB.DataApi/Tables/Table.cs
+++ b/src/DataStax.AstraDB.DataApi/Tables/Table.cs
@@ -881,7 +881,7 @@ public class Table<T> where T : class
     /// </remarks>
     public TableFindCursor<T> Find()
     {
-        return Find(null, null);
+        return Find(null, null, null);
     }
 
     /// <inheritdoc cref="Find()"/>
@@ -900,14 +900,14 @@ public class Table<T> where T : class
     /// </example>
     public TableFindCursor<T> Find(TableFilter<T> filter)
     {
-        return Find(filter, null);
+        return Find(filter, null, null);
     }
 
     /// <inheritdoc cref="Find()" path="/summary"/>
     /// <param name="findOptions"></param>
     public TableFindCursor<T> Find(TableFindManyOptions<T> findOptions)
     {
-        return Find(null, findOptions);
+        return Find(null, findOptions, null);
     }
 
     /// <inheritdoc cref="Find(TableFilter{T})"/>
@@ -916,7 +916,17 @@ public class Table<T> where T : class
     public TableFindCursor<T> Find(TableFilter<T> filter, TableFindManyOptions<T> findOptions)
     {
         findOptions ??= new TableFindManyOptions<T>();
-        return new(findOptions.WithFilterParam(filter), null, RunFindManyAsync);
+        return Find(filter, findOptions, null);
+    }
+
+    /// <inheritdoc cref="Find(TableFilter{T}, TableFindManyOptions{T})"/>
+    /// <param name="filter"></param>
+    /// <param name="findOptions"></param>
+    /// <param name="commandOptions"></param>
+    public TableFindCursor<T> Find(TableFilter<T> filter, TableFindManyOptions<T> findOptions, CommandOptions commandOptions)
+    {
+        findOptions ??= new TableFindManyOptions<T>();
+        return new(findOptions.WithFilterParam(filter), commandOptions, RunFindManyAsync);
     }
 
     /// <inheritdoc cref="Find()" path="/summary"/>
@@ -926,7 +936,7 @@ public class Table<T> where T : class
     /// </remarks>
     public TableFindCursor<T, TResult> Find<TResult>() where TResult : class
     {
-        return Find<TResult>(null, null);
+        return Find<TResult>(null, null, null);
     }
 
     /// <inheritdoc cref="Find(TableFilter{T})"/>
@@ -936,7 +946,7 @@ public class Table<T> where T : class
     /// </remarks>
     public TableFindCursor<T, TResult> Find<TResult>(TableFilter<T> filter) where TResult : class
     {
-        return Find<TResult>(filter, null);
+        return Find<TResult>(filter, null, null);
     }
 
     /// <inheritdoc cref="Find(TableFindManyOptions{T})"/>
@@ -946,16 +956,28 @@ public class Table<T> where T : class
     /// </remarks>
     public TableFindCursor<T, TResult> Find<TResult>(TableFindManyOptions<T> findOptions) where TResult : class
     {
-        return Find<TResult>(null, findOptions);
+        return Find<TResult>(null, findOptions, null);
     }
 
-    /// <inheritdoc cref="Find{TResult}(TableFilter{T})"/>
-    /// <param name="filter"></param>
-    /// <param name="findOptions"></param>
+    /// <inheritdoc cref="Find(TableFilter{T}, TableFindManyOptions{T})"/>
+    /// <remarks>
+    /// The Find alternatives that accept a TResult type parameter allow for deserializing the row as a different type
+    /// (most commonly used when using projection to return a subset of fields)
+    /// </remarks>
     public TableFindCursor<T, TResult> Find<TResult>(TableFilter<T> filter, TableFindManyOptions<T> findOptions) where TResult : class
     {
+        return Find<TResult>(filter, findOptions, null);
+    }
+
+    /// <inheritdoc cref="Find(TableFilter{T}, TableFindManyOptions{T}, CommandOptions)"/>
+    /// <remarks>
+    /// The Find alternatives that accept a TResult type parameter allow for deserializing the row as a different type
+    /// (most commonly used when using projection to return a subset of fields)
+    /// </remarks>
+    public TableFindCursor<T, TResult> Find<TResult>(TableFilter<T> filter, TableFindManyOptions<T> findOptions, CommandOptions commandOptions) where TResult : class
+    {
         findOptions ??= new TableFindManyOptions<T>();
-        return new(findOptions.WithFilterParam(filter), null, RunFindManyAsync);
+        return new(findOptions.WithFilterParam(filter), commandOptions, RunFindManyAsync);
     }
 
     internal async Task<FindPage<TResult>> RunFindManyAsync<TResult>(TableFindCursor<T, TResult> cursor, string nextPageState, bool runSynchronously) where TResult : class

--- a/src/DataStax.AstraDB.DataApi/Tables/Table.cs
+++ b/src/DataStax.AstraDB.DataApi/Tables/Table.cs
@@ -652,21 +652,12 @@ public class Table<T> where T : class
     //
 
     /// <summary>
-    /// This is a synchronous version of <see cref="InsertManyAsync(IEnumerable{T}, InsertManyOptions, CommandOptions)"/>
+    /// Synchronous version of <see cref="InsertManyAsync(IEnumerable{T})"/>
     /// </summary>
-    /// <inheritdoc cref="InsertManyAsync(IEnumerable{T}, InsertManyOptions, CommandOptions)"/>
+    /// <inheritdoc cref="InsertManyAsync(IEnumerable{T})"/>
     public TableInsertManyResult InsertMany(IEnumerable<T> rows)
     {
-        return InsertMany(rows, null as CommandOptions);
-    }
-
-    /// <summary>
-    /// Synchronous version of <see cref="InsertManyAsync(IEnumerable{T}, CommandOptions)"/>
-    /// </summary>
-    /// <inheritdoc cref="InsertManyAsync(IEnumerable{T}, CommandOptions)"/>
-    public TableInsertManyResult InsertMany(IEnumerable<T> rows, CommandOptions commandOptions)
-    {
-        return InsertManyAsync(rows, null, commandOptions, true).ResultSync();
+        return InsertMany(rows, null);
     }
 
     /// <summary>
@@ -675,55 +666,38 @@ public class Table<T> where T : class
     /// <inheritdoc cref="InsertManyAsync(IEnumerable{T}, InsertManyOptions)"/>
     public TableInsertManyResult InsertMany(IEnumerable<T> rows, InsertManyOptions insertOptions)
     {
-        return InsertManyAsync(rows, insertOptions, null, true).ResultSync();
+        return InsertManyAsync(rows, insertOptions, runSynchronously: true).ResultSync();
     }
 
     /// <summary>
-    /// Insert multiple rows into the table.
+    /// Asynchronously insert multiple rows into the table.
     /// </summary>
-    /// <param name="rows"></param>
+    /// <param name="rows">The list of rows to insert.</param>
     /// <returns></returns>
     /// <remarks>
-    /// If you need to control concurrency, chunk size, or whether the insert is ordered or not, use the <see cref="InsertManyAsync(IEnumerable{T}, InsertManyOptions)"/> overload.
-    /// To additionally control timesouts, use the <see cref="InsertManyAsync(IEnumerable{T}, InsertManyOptions, CommandOptions)"/> overload.
+    /// If you need to control concurrency, chunk size, whether the insert is ordered or not, or other options, use the <see cref="InsertManyAsync(IEnumerable{T}, InsertManyOptions)"/> overload.
     /// </remarks>
-    /// <throws cref="ArgumentException">Thrown if the rows collection is null or empty.</throws>
-    /// <throws cref="BulkOperationException{TableInsertManyResult}">Thrown if an error occurs during the bulk operation, with partial results returned in the <see cref="BulkOperationException{TableInsertManyResult}.PartialResult"/> property.</throws>
+    /// <throws cref="BulkOperationException{T}">Thrown if an error occurs during the bulk operation,
+    /// with partial results returned in the <see cref="BulkOperationException{T}.PartialResult"/> property.</throws>
     public Task<TableInsertManyResult> InsertManyAsync(IEnumerable<T> rows)
     {
-        return InsertManyAsync(rows, null, null, false);
+        return InsertManyAsync(rows, null);
     }
 
     /// <inheritdoc cref="InsertManyAsync(IEnumerable{T})"/>
-    /// <param name="rows"></param>
-    /// <param name="commandOptions"></param>
-    public Task<TableInsertManyResult> InsertManyAsync(IEnumerable<T> rows, CommandOptions commandOptions)
-    {
-        return InsertManyAsync(rows, null, commandOptions, false);
-    }
-
-    /// <inheritdoc cref="InsertManyAsync(IEnumerable{T})"/>
-    /// <param name="rows"></param>
-    /// <param name="insertOptions"></param>
+    /// <param name="rows">The list of rows to insert.</param>
+    /// <param name="insertOptions">Allows specifying the insertion chunk size, ordered/unordered mode, concurrency, as well as other generic command-execution options.</param>
     public Task<TableInsertManyResult> InsertManyAsync(IEnumerable<T> rows, InsertManyOptions insertOptions)
     {
-        return InsertManyAsync(rows, insertOptions, null, false);
+        return InsertManyAsync(rows, insertOptions, runSynchronously: false);
     }
 
-    /// <inheritdoc cref="InsertManyAsync(IEnumerable{T}, CommandOptions)"/>
-    /// <param name="rows"></param>
-    /// <param name="insertOptions"></param>
-    /// <param name="commandOptions"></param>
-    public Task<TableInsertManyResult> InsertManyAsync(IEnumerable<T> rows, InsertManyOptions insertOptions, CommandOptions commandOptions)
+    private async Task<TableInsertManyResult> InsertManyAsync(IEnumerable<T> rows, InsertManyOptions insertOptions, bool runSynchronously)
     {
-        return InsertManyAsync(rows, insertOptions, commandOptions, false);
-    }
-
-    private async Task<TableInsertManyResult> InsertManyAsync(IEnumerable<T> rows, InsertManyOptions insertOptions, CommandOptions commandOptions, bool runSynchronously)
-    {
-        Guard.NotNullOrEmpty(rows, nameof(rows));
+        Guard.NotNull(rows, nameof(rows));
 
         if (insertOptions == null) insertOptions = new InsertManyOptions();
+        var commandOptions = insertOptions.CommandOptions();
         if (insertOptions.Concurrency > 1 && insertOptions.Ordered)
         {
             throw new ArgumentException("Cannot run ordered insert_many concurrently.");

--- a/src/DataStax.AstraDB.DataApi/Tables/Table.cs
+++ b/src/DataStax.AstraDB.DataApi/Tables/Table.cs
@@ -967,7 +967,7 @@ public class Table<T> where T : class
         var options = cursor.FindOptions.Clone();
         options.PageState = nextPageState;
 
-        var payloadOptions = options.payloadOptions();
+        var payloadOptions = options.PayloadOptions();
         var commandOptions = SetRowSerializationOptions<TResult>(cursor.CommandOptions, false);
         var command = CreateCommand("find").WithPayload(payloadOptions).AddCommandOptions(commandOptions);
         var response = await command.RunAsyncReturnData<APIFindResult<TResult>, TableFindStatusResult>(runSynchronously).ConfigureAwait(false);

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/CollectionCursorTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/CollectionCursorTests.cs
@@ -26,6 +26,8 @@ public class CollectionCursorTests
         _fixture = fixture;
     }
 
+    // This one is skipped on HCD because in some cases a wrong token will *not* bring failure
+    [SkipWhenNotAstra]
     [Fact]
     public async Task Test_CollectionCursor_CommandOptions()
     {

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/CollectionCursorTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/CollectionCursorTests.cs
@@ -32,13 +32,16 @@ public class CollectionCursorTests
         var filledCollection = _fixture.FilledCollection;
 
         var theFilter = Builders<CursorTestDocument>.CollectionFilter.Gt(d => d.PInt, 2);
-        var theFindOptions = new CollectionFindManyOptions<CursorTestDocument> {
+        var theGoodFindOptions = new CollectionFindManyOptions<CursorTestDocument> {
             Sort = Builders<CursorTestDocument>.CollectionSort.Descending(d => d.PInt)
         };
-        var theBadToken = new CommandOptions { Token = "blibblo" };
+        var theBadFindOptions = new CollectionFindManyOptions<CursorTestDocument> {
+            Sort = Builders<CursorTestDocument>.CollectionSort.Descending(d => d.PInt),
+            Token = "blibblo"
+        };
 
-        var goodCur = filledCollection.Find(theFilter, theFindOptions);
-        var badCur = filledCollection.Find(theFilter, theFindOptions, theBadToken);
+        var goodCur = filledCollection.Find(theFilter, theGoodFindOptions);
+        var badCur = filledCollection.Find(theFilter, theBadFindOptions);
 
         await foreach (var item in goodCur) { /* moot */ };
         await Assert.ThrowsAsync<System.UnauthorizedAccessException>( async () =>

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/CollectionCursorTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/CollectionCursorTests.cs
@@ -2,6 +2,7 @@ using DataStax.AstraDB.DataApi.Collections;
 using DataStax.AstraDB.DataApi.Core;
 using DataStax.AstraDB.DataApi.Core.Commands;
 using DataStax.AstraDB.DataApi.Core.Enumeration;
+using DataStax.AstraDB.DataApi.Core.Query;
 using DataStax.AstraDB.DataApi.Core.Results;
 using DataStax.AstraDB.DataApi.IntegrationTests.Fixtures;
 using DataStax.AstraDB.DataApi.SerDes;
@@ -23,6 +24,27 @@ public class CollectionCursorTests
     public CollectionCursorTests(AssemblyFixture assemblyFixture, CollectionCursorFixture fixture)
     {
         _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task Test_CollectionCursor_CommandOptions()
+    {
+        var filledCollection = _fixture.FilledCollection;
+
+        var theFilter = Builders<CursorTestDocument>.CollectionFilter.Gt(d => d.PInt, 2);
+        var theFindOptions = new CollectionFindManyOptions<CursorTestDocument> {
+            Sort = Builders<CursorTestDocument>.CollectionSort.Descending(d => d.PInt)
+        };
+        var theBadToken = new CommandOptions { Token = "blibblo" };
+
+        var goodCur = filledCollection.Find(theFilter, theFindOptions);
+        var badCur = filledCollection.Find(theFilter, theFindOptions, theBadToken);
+
+        await foreach (var item in goodCur) { /* moot */ };
+        await Assert.ThrowsAsync<System.UnauthorizedAccessException>( async () =>
+        {
+            await foreach (var item in badCur) { /* moot */ }
+        });
     }
 
     [Fact]

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/CollectionTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/CollectionTests.cs
@@ -628,6 +628,38 @@ public class CollectionTests
         }
     }
 
+    [SkipWhenNotAstra]
+    [Fact]
+    public async Task InsertManyCommandOptions()
+    {
+        var collectionName = "simpleObjects";
+        try
+        {
+            List<SimpleObject> items = new List<SimpleObject>();
+            for (var i = 0; i < 10; i++)
+            {
+                items.Add(new SimpleObject()
+                {
+                    _id = i,
+                    Name = $"Test Object {i}"
+                });
+            }
+            ;
+            var collection = await fixture.Database.CreateCollectionAsync<SimpleObject, int>(collectionName);
+
+            // passing generic command options:
+            await Assert.ThrowsAsync<BulkOperationException<CollectionInsertManyResult>>( async () =>
+            {
+                await collection.InsertManyAsync(
+                    items, new InsertManyOptions() { Token = "blibbli" });
+            });
+        }
+        finally
+        {
+            await fixture.Database.DropCollectionAsync(collectionName);
+        }
+    }
+
     [Fact]
     public async Task CountDocuments_NoFilter_ReturnsCorrectCount()
     {

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/CollectionTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/CollectionTests.cs
@@ -648,7 +648,7 @@ public class CollectionTests
             var collection = await fixture.Database.CreateCollectionAsync<SimpleObject, int>(collectionName);
 
             // passing generic command options:
-            await Assert.ThrowsAsync<BulkOperationException<CollectionInsertManyResult>>( async () =>
+            await Assert.ThrowsAsync<BulkOperationException<CollectionInsertManyResult<int>>>( async () =>
             {
                 await collection.InsertManyAsync(
                     items, new InsertManyOptions() { Token = "blibbli" });

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/TableTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/TableTests.cs
@@ -1,5 +1,6 @@
 using DataStax.AstraDB.DataApi.Core;
 using DataStax.AstraDB.DataApi.Core.Query;
+using DataStax.AstraDB.DataApi.Core.Results;
 using DataStax.AstraDB.DataApi.IntegrationTests.Fixtures;
 using DataStax.AstraDB.DataApi.Tables;
 using Microsoft.VisualBasic;
@@ -49,6 +50,45 @@ public class TableTests
             Assert.Equal(rows[0].NumberOfPages, result.InsertedIdTuples[0][1]);
             Assert.Equal(rows[1].Title, result.InsertedIdTuples[1][0]);
             Assert.Equal(rows[1].NumberOfPages, result.InsertedIdTuples[1][1]);
+        }
+        finally
+        {
+            await fixture.Database.DropTableAsync(tableName);
+        }
+    }
+
+    [SkipWhenNotAstra]
+    [Fact]
+    public async Task InsertManyCommandOptions()
+    {
+        var tableName = "insertRowsTest";
+        try
+        {
+            var table = await fixture.Database.CreateTableAsync<RowBook>(tableName);
+            var row1 = new RowBook()
+            {
+                Title = "Computed Wilderness",
+                Author = "Ryan Eau",
+                NumberOfPages = 432,
+                DueDate = DateTime.UtcNow - TimeSpan.FromDays(1),
+                Genres = new HashSet<string> { "History", "Biography" }
+            };
+            var row2 = new RowBook()
+            {
+                Title = "Desert Peace",
+                Author = "Walter Dray",
+                NumberOfPages = 355,
+                DueDate = DateTime.UtcNow - TimeSpan.FromDays(2),
+                Genres = new HashSet<string> { "Fiction" }
+            };
+            var rows = new List<RowBook> { row1, row2 };
+
+            // passing generic command options:
+            await Assert.ThrowsAsync<BulkOperationException<TableInsertManyResult>>( async () =>
+            {
+                await table.InsertManyAsync(
+                    rows, new InsertManyOptions() { Token = "blibbli" });
+            });
         }
         finally
         {


### PR DESCRIPTION
Fixes #179 .

Fixes #166 .
(while we're at it...)

Fixes [#185](https://github.com/datastax/astra-db-csharp/issues/185) as well.

~Specifically it adds a single overload with all three parameters, likely enough for the (probably uncommon) case of users who want to set options to the cursor.~
Update: changed to use a single options parameter that now also includes the CommandOptions stuff.


Along the way, a little restructuring of the xmldocs is done (now it's uniformly structured).

Also a basic test is added to check the options do indeed make their way to the fecth-page executions.

_Note: changes like this would require a duplicate test on tables to really test everything. Note for the future: expand test coverage, since not everything about find is in the shared Abstract/Cursor classes._