### PR TITLE
database's `GetAdmin` gains a type parameter (+tests)

### DIFF
--- a/src/DataStax.AstraDB.DataApi/Core/Database.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/Database.cs
@@ -612,18 +612,23 @@ public class Database
     /// <summary>
     /// Returns an instance of <see cref="IDatabaseAdmin"/> that can be used to perform database management operations for this database
     /// </summary>
-    /// <returns></returns>
+    /// <returns>An appropriate database admin instance</returns>
+    /// <exception cref="ArgumentException">
+    /// Thrown when the options request a different destination
+    /// </exception>
+    /// <remarks>
+    /// The type-parameterized form of this method, <see cref="GetAdmin{TAdmin}()"/>, is recommended for a more type-safe code.
+    /// </remarks>
     public IDatabaseAdmin GetAdmin()
     {
         return GetAdmin(null);
     }
 
-    /// <summary>
-    /// Returns an instance of <see cref="IDatabaseAdmin"/> that can be used to perform database management operations for this database
-    /// </summary>
-    /// <param name="options">The options to use for the command, useful for overriding the destination database</param>
-    /// <returns></returns>
-    /// <exception cref="ArgumentException">Thrown when the destination is not the same for all CommandOptions when overriding the default destination</exception>
+    /// <inheritdoc cref="GetAdmin()"/>
+    /// <param name="options">The options to use for the command, useful e.g. for customizing timeout settings</param>
+    /// <remarks>
+    /// The type-parameterized form of this method, <see cref="GetAdmin{TAdmin}(CommandOptions)"/>, is recommended for a more type-safe code.
+    /// </remarks>
     public IDatabaseAdmin GetAdmin(CommandOptions options)
     {
         var mergedOptions = CommandOptions.Merge(CommandOptions.Merge(OptionsTree), options);
@@ -638,6 +643,52 @@ public class Database
             return new DatabaseAdminAstra(this, _client, mergedOptions);
         }
         return new DatabaseAdminDataAPI(this, _client, mergedOptions);
+    }
+
+    /// <summary>
+    /// Returns an instance of <typeparamref name="TAdmin"/> that can be used to perform database management operations for this database
+    /// </summary>
+    /// <typeparam name="TAdmin">
+    /// The type of database admin to return. Must be either <see cref="DatabaseAdminAstra"/> or <see cref="DatabaseAdminDataAPI"/>
+    /// </typeparam>
+    /// <returns>An instance of the specified admin type</returns>
+    /// <exception cref="ArgumentException">
+    /// Thrown when the options request a different destination, or when the resulting admin does not match the provided <typeparamref name="TAdmin"/>
+    /// </exception>
+    public TAdmin GetAdmin<TAdmin>() where TAdmin : IDatabaseAdmin
+    {
+        return GetAdmin<TAdmin>(null);
+    }
+
+    /// <inheritdoc cref="GetAdmin{TAdmin}()"/>
+    /// <param name="options">The options to use for the command, useful e.g. for customizing timeout settings</param>
+    public TAdmin GetAdmin<TAdmin>(CommandOptions options) where TAdmin : IDatabaseAdmin
+    {
+        var mergedOptions = CommandOptions.Merge(CommandOptions.Merge(OptionsTree), options);
+
+        if (options is { Destination: not null } && mergedOptions is { Destination: not null } && options.Destination != mergedOptions.Destination)
+        {
+            throw new ArgumentException("Destination must be the same for all CommandOptions when overriding the default destination");
+        }
+
+        IDatabaseAdmin admin;
+        if (mergedOptions.Destination == DataAPIDestination.ASTRA)
+        {
+            admin = new DatabaseAdminAstra(this, _client, mergedOptions);
+        }
+        else
+        {
+            admin = new DatabaseAdminDataAPI(this, _client, mergedOptions);
+        }
+
+        // Validate that the requested type matches the actual admin type
+        if (admin is not TAdmin typedAdmin)
+        {
+            throw new ArgumentException(
+                $"Requested a {typeof(TAdmin).Name}, but produced a {admin.GetType().Name}");
+        }
+
+        return typedAdmin;
     }
 
     /// <summary>

--- a/src/DataStax.AstraDB.DataApi/Core/Database.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/Database.cs
@@ -612,6 +612,7 @@ public class Database
     /// <summary>
     /// Returns an instance of <see cref="IDatabaseAdmin"/> that can be used to perform database management operations for this database
     /// </summary>
+    /// <param name="options">Optional. The options for the admin, useful e.g. for customizing timeout settings</param>
     /// <returns>An appropriate database admin instance</returns>
     /// <exception cref="ArgumentException">
     /// Thrown when the options request a different destination
@@ -619,18 +620,9 @@ public class Database
     /// <remarks>
     /// The type-parameterized form of this method, <see cref="GetAdmin{TAdmin}()"/>, is recommended for a more type-safe code.
     /// </remarks>
-    public IDatabaseAdmin GetAdmin()
+    public IDatabaseAdmin GetAdmin(CommandOptions options = null)
     {
-        return GetAdmin(null);
-    }
-
-    /// <inheritdoc cref="GetAdmin()"/>
-    /// <param name="options">The options to use for the command, useful e.g. for customizing timeout settings</param>
-    /// <remarks>
-    /// The type-parameterized form of this method, <see cref="GetAdmin{TAdmin}(CommandOptions)"/>, is recommended for a more type-safe code.
-    /// </remarks>
-    public IDatabaseAdmin GetAdmin(CommandOptions options)
-    {
+        options ??= new();
         var mergedOptions = CommandOptions.Merge(CommandOptions.Merge(OptionsTree), options);
 
         if (options is { Destination: not null } && mergedOptions is { Destination: not null } && options.Destination != mergedOptions.Destination)
@@ -651,26 +643,21 @@ public class Database
     /// <typeparam name="TAdmin">
     /// The type of database admin to return. Must be either <see cref="DatabaseAdminAstra"/> or <see cref="DatabaseAdminDataAPI"/>
     /// </typeparam>
+    /// <param name="options">Optional. The options for the admin, useful e.g. for customizing timeout settings</param>
     /// <returns>An instance of the specified admin type</returns>
     /// <exception cref="ArgumentException">
     /// Thrown when the options request a different destination, or when the resulting admin does not match the provided <typeparamref name="TAdmin"/>
     /// </exception>
-    public TAdmin GetAdmin<TAdmin>() where TAdmin : IDatabaseAdmin
-    {
-        return GetAdmin<TAdmin>(null);
-    }
-
-    /// <inheritdoc cref="GetAdmin{TAdmin}()"/>
-    /// <param name="options">The options to use for the command, useful e.g. for customizing timeout settings</param>
-    public TAdmin GetAdmin<TAdmin>(CommandOptions options) where TAdmin : IDatabaseAdmin
+    public TAdmin GetAdmin<TAdmin>(CommandOptions options = null) where TAdmin : IDatabaseAdmin
     {
         IDatabaseAdmin admin = GetAdmin(options);
 
-        // Validate that the requested type matches the actual admin type
+        // Actual type validation
         if (admin is not TAdmin typedAdmin)
         {
             throw new ArgumentException(
-                $"Requested a {typeof(TAdmin).Name}, but produced a {admin.GetType().Name}");
+                $"Requested a {typeof(TAdmin).Name}, but produced a {admin.GetType().Name}. " +
+                "Please ensure the requested admin type matches the database 'Destination'.");
         }
 
         return typedAdmin;

--- a/src/DataStax.AstraDB.DataApi/Core/Database.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/Database.cs
@@ -664,22 +664,7 @@ public class Database
     /// <param name="options">The options to use for the command, useful e.g. for customizing timeout settings</param>
     public TAdmin GetAdmin<TAdmin>(CommandOptions options) where TAdmin : IDatabaseAdmin
     {
-        var mergedOptions = CommandOptions.Merge(CommandOptions.Merge(OptionsTree), options);
-
-        if (options is { Destination: not null } && mergedOptions is { Destination: not null } && options.Destination != mergedOptions.Destination)
-        {
-            throw new ArgumentException("Destination must be the same for all CommandOptions when overriding the default destination");
-        }
-
-        IDatabaseAdmin admin;
-        if (mergedOptions.Destination == DataAPIDestination.ASTRA)
-        {
-            admin = new DatabaseAdminAstra(this, _client, mergedOptions);
-        }
-        else
-        {
-            admin = new DatabaseAdminDataAPI(this, _client, mergedOptions);
-        }
+        IDatabaseAdmin admin = GetAdmin(options);
 
         // Validate that the requested type matches the actual admin type
         if (admin is not TAdmin typedAdmin)

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdminTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdminTests.cs
@@ -211,6 +211,36 @@ public class AdminTests
         Assert.NotNull(names);
     }
 
+    [SkipWhenNotAstra]
+    [Fact]
+    public async Task DatabaseAdmin_GetAdmin_TypedPatterns_Astra()
+    {
+        var database = fixture.Client.GetDatabase(fixture.DatabaseUrl, fixture.Token);
+
+        var genAdmin = database.GetAdmin();
+        var astraAdmin = database.GetAdmin<DatabaseAdminAstra>();
+
+        Assert.IsType<DatabaseAdminAstra>(astraAdmin);
+        Assert.Throws<ArgumentException>(() =>
+            database.GetAdmin<DatabaseAdminDataAPI>()
+        );
+    }
+
+    [SkipWhenAstra]
+    [Fact]
+    public async Task DatabaseAdmin_GetAdmin_TypedPatterns_NonAstra()
+    {
+        var database = fixture.Client.GetDatabase(fixture.DatabaseUrl, fixture.Token);
+
+        var genAdmin = database.GetAdmin();
+        var hcdAdmin = database.GetAdmin<DatabaseAdminDataAPI>();
+
+        Assert.IsType<DatabaseAdminDataAPI>(hcdAdmin);
+        Assert.Throws<ArgumentException>(() =>
+            database.GetAdmin<DatabaseAdminAstra>()
+        );
+    }
+
     [Fact]
     public async Task DatabaseAdmin_DoesKeyspaceExist()
     {

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdminTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdminTests.cs
@@ -216,13 +216,20 @@ public class AdminTests
     public async Task DatabaseAdmin_GetAdmin_TypedPatterns_Astra()
     {
         var database = fixture.Client.GetDatabase(fixture.DatabaseUrl, fixture.Token);
+        var options = new CommandOptions();
 
         var genAdmin = database.GetAdmin();
         var astraAdmin = database.GetAdmin<DatabaseAdminAstra>();
+        var genAdminO = database.GetAdmin(options);
+        var astraAdminO = database.GetAdmin<DatabaseAdminAstra>(options);
 
         Assert.IsType<DatabaseAdminAstra>(astraAdmin);
         Assert.Throws<ArgumentException>(() =>
             database.GetAdmin<DatabaseAdminDataAPI>()
+        );
+        Assert.IsType<DatabaseAdminAstra>(astraAdminO);
+        Assert.Throws<ArgumentException>(() =>
+            database.GetAdmin<DatabaseAdminDataAPI>(options)
         );
     }
 
@@ -231,13 +238,20 @@ public class AdminTests
     public async Task DatabaseAdmin_GetAdmin_TypedPatterns_NonAstra()
     {
         var database = fixture.Client.GetDatabase(fixture.DatabaseUrl, fixture.Token);
+        var options = new CommandOptions();
 
         var genAdmin = database.GetAdmin();
         var hcdAdmin = database.GetAdmin<DatabaseAdminDataAPI>();
+        var genAdminO = database.GetAdmin(options);
+        var hcdAdminO = database.GetAdmin<DatabaseAdminDataAPI>(options);
 
         Assert.IsType<DatabaseAdminDataAPI>(hcdAdmin);
         Assert.Throws<ArgumentException>(() =>
             database.GetAdmin<DatabaseAdminAstra>()
+        );
+        Assert.IsType<DatabaseAdminDataAPI>(hcdAdminO);
+        Assert.Throws<ArgumentException>(() =>
+            database.GetAdmin<DatabaseAdminAstra>(options)
         );
     }
 


### PR DESCRIPTION
This introduced a stronger typed pattern for getting an admin from a database, e.g.:

```
var astraAdmin = database.GetAdmin<DatabaseAdminAstra>();
```

(see added tests).

This is critical e.g. when passing replication options in a CreateKeyspace non-Astra method call, etc.

_Backward-compatible overloads_, whose return type is `IDatabaseAdmin`, are still present. (though IMO the docs should only feature the "better" form).
