### PR TITLE
User-Agent header from CommandOptions dedicated setting

### DIFF
--- a/src/DataStax.AstraDB.DataApi/Core/APICaller.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/APICaller.cs
@@ -33,7 +33,7 @@ public class APICaller
     /// </summary>
     public string Version { get; set; } = null;
 
-    internal string ToString()
+    new internal string ToString()
     {
         if (Name == null && Version == null)
         {

--- a/src/DataStax.AstraDB.DataApi/Core/APICaller.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/APICaller.cs
@@ -1,0 +1,57 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Collections.Generic;
+
+namespace DataStax.AstraDB.DataApi.Core;
+
+/// <summary>
+/// A single layer of 'caller information' for self-identifying when issuing API requests.
+/// </summary>
+public class APICaller
+{
+    /// <summary>
+    /// Name of the caller (in most cases, a package name)
+    /// </summary>
+    public string Name { get; set; } = null;
+
+    /// <summary>
+    /// Version of the caller, typically in dot-notation.
+    /// </summary>
+    public string Version { get; set; } = null;
+
+    internal string ToString()
+    {
+        if (Name == null && Version == null)
+        {
+            return null;
+        }
+        var parts = new List<string>();
+        if (Name != null) parts.Add(Name);
+        if (Version != null) parts.Add(Version);
+        return string.Join("/", parts);
+    }
+
+    static internal string ToString(List<APICaller> callers) {
+        var callerStrings = new List<string>();
+        foreach (var caller in callers)
+        {
+            var callerString = caller.ToString();
+            if (callerString != null) callerStrings.Add(callerString);
+        }
+        return string.Join(" ", callerStrings);
+    }
+}

--- a/src/DataStax.AstraDB.DataApi/Core/APICaller.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/APICaller.cs
@@ -35,14 +35,21 @@ public class APICaller
 
     new internal string ToString()
     {
-        if (Name == null && Version == null)
+        if (Name == null)
         {
             return null;
         }
-        var parts = new List<string>();
-        if (Name != null) parts.Add(Name);
-        if (Version != null) parts.Add(Version);
-        return string.Join("/", parts);
+        else
+        {
+            if (Version != null)
+            {
+                return $"{Name}/{Version}";
+            }
+            else
+            {
+                return Name;
+            }
+        }
     }
 
     static internal string ToHeaderString(List<APICaller> callers) {

--- a/src/DataStax.AstraDB.DataApi/Core/APICaller.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/APICaller.cs
@@ -45,7 +45,7 @@ public class APICaller
         return string.Join("/", parts);
     }
 
-    static internal string ToString(List<APICaller> callers) {
+    static internal string ToHeaderString(List<APICaller> callers) {
         var callerStrings = new List<string>();
         foreach (var caller in callers)
         {

--- a/src/DataStax.AstraDB.DataApi/Core/CommandOptions.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/CommandOptions.cs
@@ -76,6 +76,13 @@ public class CommandOptions
     public HttpClientOptions HttpClientOptions { get; set; }
 
     /// <summary>
+    /// List of API callers for self-identification in API requests, arranged hierarchically:
+    /// conventionally, the lowest-level component of the stack is in the last position.
+    /// </summary>
+    [JsonIgnore]
+    public List<APICaller> APICallers { get; set; }
+
+    /// <summary>
     /// Specify various timeout options to use for the command execution.
     /// </summary>
     /// <remarks>
@@ -158,6 +165,7 @@ public class CommandOptions
             SerializeIEEE754SpecialValues = FirstNonNull(x => x.SerializeIEEE754SpecialValues) ?? Defaults().SerializeIEEE754SpecialValues,
             DeserializeToObjectDictionary = FirstNonNull(x => x.DeserializeToObjectDictionary) ?? Defaults().DeserializeToObjectDictionary,
             BulkOperationCancellationToken = list.Select(o => o.BulkOperationCancellationToken).Merge(),
+            APICallers = list.Select(o => o.APICallers).Merge(),
             AdditionalHeaders = list
                 .Select(o => o.AdditionalHeaders)
                 .Where(d => d != null)

--- a/src/DataStax.AstraDB.DataApi/Core/Commands/Command.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/Commands/Command.cs
@@ -54,10 +54,32 @@ internal class Command
     private const string ClientAPICallerName = "astra-db-csharp";
     private static readonly APICaller ClientAPICaller = new APICaller() {
         Name = ClientAPICallerName,
-        Version = (
-            Assembly.GetExecutingAssembly().GetName().Version
-        )?.ToString()
+        Version = GetAssemblyVersion()
     };
+
+    private static string GetAssemblyVersion()
+    {
+        try
+        {
+            var assembly = Assembly.GetExecutingAssembly();
+            // Try full version string identifier:
+            var infoVersion = assembly
+                .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+                ?.InformationalVersion;
+            if (!string.IsNullOrEmpty(infoVersion))
+            {
+                // Strip away the trailing git commit SHA if present
+                var plusIndex = infoVersion.IndexOf('+');
+                return plusIndex >= 0 ? infoVersion.Substring(0, plusIndex) : infoVersion;
+            }
+            // Numeric-only version as fallback:
+            return assembly.GetName().Version?.ToString();
+        }
+        catch
+        {
+            return null;
+        }
+    }
 
     internal Command(DataAPIClient client, CommandOptions[] options, CommandUrlBuilder urlBuilder) : this(null, client, options, urlBuilder)
     {
@@ -343,7 +365,7 @@ internal class Command
             fullCallers.AddRange(commandOptions.APICallers);
         }
         fullCallers.Add(ClientAPICaller);
-        request.Headers.Add("User-Agent", APICaller.ToString(fullCallers));
+        request.Headers.Add("User-Agent", APICaller.ToHeaderString(fullCallers));
 
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", commandOptions.Token);
         request.Headers.Add("Token", commandOptions.Token);

--- a/src/DataStax.AstraDB.DataApi/Core/Commands/Command.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/Commands/Command.cs
@@ -23,6 +23,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Reflection;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -49,6 +50,14 @@ internal class Command
 
     private Func<HttpResponseMessage, Task> _responseHandler;
     internal Func<HttpResponseMessage, Task> ResponseHandler { set { _responseHandler = value; } }
+
+    private const string ClientAPICallerName = "astra-db-csharp";
+    private static readonly APICaller ClientAPICaller = new APICaller() {
+        Name = ClientAPICallerName,
+        Version = (
+            Assembly.GetExecutingAssembly().GetName().Version
+        )?.ToString()
+    };
 
     internal Command(DataAPIClient client, CommandOptions[] options, CommandUrlBuilder urlBuilder) : this(null, client, options, urlBuilder)
     {
@@ -329,6 +338,13 @@ internal class Command
             request.Version = commandOptions.HttpClientOptions.HttpVersion;
         }
 
+        var fullCallers = new List<APICaller>();
+        if ( commandOptions.APICallers != null ) {
+            fullCallers.AddRange(commandOptions.APICallers);
+        }
+        fullCallers.Add(ClientAPICaller);
+        request.Headers.Add("User-Agent", APICaller.ToString(fullCallers));
+
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", commandOptions.Token);
         request.Headers.Add("Token", commandOptions.Token);
         if (commandOptions.AdditionalHeaders != null)
@@ -340,6 +356,10 @@ internal class Command
         }
 
         MaybeLogDebugMessage("Headers: {Headers}", request.Headers);
+        // This header can contain spaces, and the GetValues returns the pieces as enumerable:
+        MaybeLogDebugMessage(
+            "User-Agent: {UserAgent}",
+            string.Join(" ", request.Headers.GetValues("User-Agent")));
 
         string responseContent = null;
         HttpResponseMessage response = null;

--- a/src/DataStax.AstraDB.DataApi/Core/Commands/Command.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/Commands/Command.cs
@@ -378,10 +378,6 @@ internal class Command
         }
 
         MaybeLogDebugMessage("Headers: {Headers}", request.Headers);
-        // This header can contain spaces, and the GetValues returns the pieces as enumerable:
-        MaybeLogDebugMessage(
-            "User-Agent: {UserAgent}",
-            string.Join(" ", request.Headers.GetValues("User-Agent")));
 
         string responseContent = null;
         HttpResponseMessage response = null;

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdminTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdminTests.cs
@@ -202,6 +202,29 @@ public class AdminTests
     }
 
     [Fact]
+    public async Task DatabaseAdmin_UserAgentTest()
+    {
+        // This test requires manual inspection of the logs for the user-agents.
+        var callers = new List<APICaller>(){
+            new (){ Name = "n1" },
+            new (){ Name = "n2", Version = "v2" },
+            new (){ },
+            new (){ Name = "n4", Version = "v4" }
+        };
+        var callerOptions = new CommandOptions(){ APICallers = callers };
+
+        var daa0 = fixture.Database.GetAdmin();
+        var daa1 = fixture.Database.GetAdmin(callerOptions);
+
+        // Expected User-Agent: "astra-db-csharp/<version>" (e.g. "2.2.0.0")
+        await daa0.ListKeyspacesAsync();
+        // expected User-Agent for these 3: "n1 n2/v2 n4/v4 astra-db-csharp/<version>"
+        await daa1.ListKeyspacesAsync();
+        await daa0.ListKeyspacesAsync(callerOptions);
+        await daa1.ListKeyspacesAsync(callerOptions);
+    }
+
+    [Fact]
     public async Task DatabaseAdmin_GetKeyspaces_TokenSuppliedToDb()
     {
         var database = fixture.Client.GetDatabase(fixture.DatabaseUrl, fixture.Token);

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdminTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdminTests.cs
@@ -202,29 +202,6 @@ public class AdminTests
     }
 
     [Fact]
-    public async Task DatabaseAdmin_UserAgentTest()
-    {
-        // This test requires manual inspection of the logs for the user-agents.
-        var callers = new List<APICaller>(){
-            new (){ Name = "n1" },
-            new (){ Name = "n2", Version = "v2" },
-            new (){ },
-            new (){ Name = "n4", Version = "v4" }
-        };
-        var callerOptions = new CommandOptions(){ APICallers = callers };
-
-        var daa0 = fixture.Database.GetAdmin();
-        var daa1 = fixture.Database.GetAdmin(callerOptions);
-
-        // Expected User-Agent: "astra-db-csharp/<version>" (e.g. "2.2.0.0")
-        await daa0.ListKeyspacesAsync();
-        // expected User-Agent for these 3: "n1 n2/v2 n4/v4 astra-db-csharp/<version>"
-        await daa1.ListKeyspacesAsync();
-        await daa0.ListKeyspacesAsync(callerOptions);
-        await daa1.ListKeyspacesAsync(callerOptions);
-    }
-
-    [Fact]
     public async Task DatabaseAdmin_GetKeyspaces_TokenSuppliedToDb()
     {
         var database = fixture.Client.GetDatabase(fixture.DatabaseUrl, fixture.Token);

--- a/test/DataStax.AstraDB.DataApi.UnitTests/APICallersTest.cs
+++ b/test/DataStax.AstraDB.DataApi.UnitTests/APICallersTest.cs
@@ -27,7 +27,7 @@ public class APICallersTests
     {
         Assert.Null(new APICaller().ToString());
         Assert.Equal("n", new APICaller(){ Name = "n" }.ToString());
-        Assert.Equal("v", new APICaller(){ Version = "v" }.ToString());
+        Assert.Null(new APICaller(){ Version = "v" }.ToString());
         Assert.Equal("n/v", new APICaller(){ Name = "n", Version = "v" }.ToString());
     }
 
@@ -43,7 +43,7 @@ public class APICallersTests
         callers.Add(new APICaller(){ Name = "n5", Version = "v5" });
 
         Assert.Equal(
-            "n2 v3 n5/v5",
+            "n2 n5/v5",
             APICaller.ToHeaderString(callers)
         );
     }

--- a/test/DataStax.AstraDB.DataApi.UnitTests/APICallersTest.cs
+++ b/test/DataStax.AstraDB.DataApi.UnitTests/APICallersTest.cs
@@ -44,7 +44,7 @@ public class APICallersTests
 
         Assert.Equal(
             "n2 v3 n5/v5",
-            APICaller.ToString(callers)
+            APICaller.ToHeaderString(callers)
         );
     }
 }

--- a/test/DataStax.AstraDB.DataApi.UnitTests/APICallersTest.cs
+++ b/test/DataStax.AstraDB.DataApi.UnitTests/APICallersTest.cs
@@ -1,0 +1,50 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using DataStax.AstraDB.DataApi.Core;
+using Xunit;
+
+namespace DataStax.AstraDB.DataApi.UnitTests;
+
+
+public class APICallersTests
+{
+    [Fact]
+    public void CallerToString()
+    {
+        Assert.Null(new APICaller().ToString());
+        Assert.Equal("n", new APICaller(){ Name = "n" }.ToString());
+        Assert.Equal("v", new APICaller(){ Version = "v" }.ToString());
+        Assert.Equal("n/v", new APICaller(){ Name = "n", Version = "v" }.ToString());
+    }
+
+    [Fact]
+    public void CallersToString()
+    {
+        var callers = new List<APICaller>();
+
+        callers.Add(new APICaller(){});
+        callers.Add(new APICaller(){ Name = "n2" });
+        callers.Add(new APICaller(){ Version = "v3" });
+        callers.Add(new APICaller(){});
+        callers.Add(new APICaller(){ Name = "n5", Version = "v5" });
+
+        Assert.Equal(
+            "n2 v3 n5/v5",
+            APICaller.ToString(callers)
+        );
+    }
+}


### PR DESCRIPTION
A minor note is that the "client version", on regular builds, right now comes with four numbers e.g. `2.2.0.0` despite the `2.2.0` in the csproj. Probably not a problem.