### PR TITLE
Minor docstring fixes around

### DIFF
--- a/index.md
+++ b/index.md
@@ -38,7 +38,11 @@ var documents = new List<SimpleObject>
 };
 var insertResult = await collection.InsertManyAsync(documents);
 
-//find a document
-var filter = Builders<SimpleObject>.Filter.Eq(so => so.Name, "Test Object 1");
-var results = await collection.Find(filter);
+//find documents
+var filter = Builders<SimpleObject>.CollectionFilter.Eq(so => so.Name, "Test Object 1");
+var cursor = collection.Find(filter);
+await foreach (var doc in cursor)
+{
+    // Process 'doc''
+}
 ```

--- a/src/DataStax.AstraDB.DataApi/Collections/Collection.cs
+++ b/src/DataStax.AstraDB.DataApi/Collections/Collection.cs
@@ -282,7 +282,7 @@ public class Collection<T, TId> where T : class
     /// <returns></returns>
     /// <example>
     /// <code>
-    /// var filter = Builders&lt;DifferentIdsObject&gt;.Filter.Eq(d => d.TheId, 1);
+    /// var filter = Builders&lt;DifferentIdsObject&gt;.CollectionFilter.Eq(d => d.TheId, 1);
     /// var result = await collection.FindOneAsync(filter);
     /// </code>
     /// </example>

--- a/src/DataStax.AstraDB.DataApi/Core/Enumeration/CollectionFindCursor.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/Enumeration/CollectionFindCursor.cs
@@ -33,8 +33,8 @@ namespace DataStax.AstraDB.DataApi.Core.Enumeration;
 /// <code>
 /// // Basic usage with foreach
 /// var cursor = collection.Find()
-///     .Filter(Builders&lt;MyDocument&gt;.Filter.Eq(d => d.Status, "active"))
-///     .Sort(Builders&lt;MyDocument&gt;.Sort.Ascending(d => d.Name))
+///     .Filter(Builders&lt;MyDocument&gt;.CollectionFilter.Eq(d => d.Status, "active"))
+///     .Sort(Builders&lt;MyDocument&gt;.CollectionSort.Ascending(d => d.Name))
 ///     .Limit(10);
 /// 
 /// foreach (var doc in cursor)

--- a/src/DataStax.AstraDB.DataApi/Core/Enumeration/FindCursor.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/Enumeration/FindCursor.cs
@@ -134,7 +134,8 @@ public abstract class FindCursor<T, TResult, TSort, TCursor> : AbstractCursor<TR
     /// <returns>A new cursor instance with the updated filter.</returns>
     /// <example>
     /// <code>
-    /// var filter = Builders&lt;MyRecord&gt;.Filter.Eq(d => d.Status, "active");
+    /// // When targeting a collection (analogous syntax for tables):
+    /// var filter = Builders&lt;MyRecord&gt;.CollectionFilter.Eq(d => d.Status, "active");
     /// var cursor = collection.Find().Filter(filter);
     /// </code>
     /// </example>
@@ -154,7 +155,7 @@ public abstract class FindCursor<T, TResult, TSort, TCursor> : AbstractCursor<TR
     /// <returns>A new cursor instance with the updated sort.</returns>
     /// <example>
     /// <code>
-    /// var sort = Builders&lt;MyRecord&gt;.Sort.Ascending(d => d.Name);
+    /// var sort = Builders&lt;MyRecord&gt;.CollectionSort.Ascending(d => d.Name);
     /// var cursor = collection.Find().Sort(sort);
     /// </code>
     /// </example>
@@ -218,7 +219,7 @@ public abstract class FindCursor<T, TResult, TSort, TCursor> : AbstractCursor<TR
     /// }
     /// 
     /// var cursor = collection.Find&lt;MyDocumentWithSimilarity&gt;()
-    ///     .Sort(Builders&lt;MyDocument&gt;.Sort.Vector(vectorQuery))
+    ///     .Sort(Builders&lt;MyDocument&gt;.CollectionSort.Vector(vectorQuery))
     ///     .IncludeSimilarity();
     /// </code>
     /// </example>
@@ -239,7 +240,7 @@ public abstract class FindCursor<T, TResult, TSort, TCursor> : AbstractCursor<TR
     /// <example>
     /// <code>
     /// var cursor = collection.Find()
-    ///     .Sort(Builders&lt;MyRecord&gt;.Sort.Vectorize("search query"))
+    ///     .Sort(Builders&lt;MyRecord&gt;.CollectionSort.Vectorize("search query"))
     ///     .IncludeSortVector();
     /// 
     /// await foreach (var doc in cursor)

--- a/src/DataStax.AstraDB.DataApi/Core/Enumeration/TableFindCursor.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/Enumeration/TableFindCursor.cs
@@ -33,8 +33,8 @@ namespace DataStax.AstraDB.DataApi.Core.Enumeration;
 /// <code>
 /// // Basic usage with foreach
 /// var cursor = table.Find()
-///     .Filter(Builders&lt;MyRow&gt;.Filter.Eq(r => r.Status, "active"))
-///     .Sort(Builders&lt;MyRow&gt;.Sort.Ascending(r => r.Name))
+///     .Filter(Builders&lt;MyRow&gt;.TableFilter.Eq(r => r.Status, "active"))
+///     .Sort(Builders&lt;MyRow&gt;.TableSort.Ascending(r => r.Name))
 ///     .Limit(10);
 /// 
 /// foreach (var row in cursor)


### PR DESCRIPTION
I just spotted a few places where the naming split for sorter and filter were not updated, docs-wise.

_Note: I did not care about `RerankSorter.cs` and `RerankTests.cs`, which are going away with PR 193 anyway._