### PR TITLE
safer release workflow + prepare to release 2.2.0-rc.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,8 @@ jobs:
 
       - name: Validate git tag version equals csproj version
         run: |
-          CSPROJ_VERSION=$(grep -oPm1 "(?<=<Version>)[^<]+" src/DataStax.AstraDB.DataApi/DataStax.AstraDB.DataApi.csproj)
+          # extract the version attribute with lookbehind and trimming spaces around:
+          CSPROJ_VERSION=$(grep -oPm1 "(?<=<Version>)\s*\K[^<]*?\S(?=\s*</Version>)" src/DataStax.AstraDB.DataApi/DataStax.AstraDB.DataApi.csproj)
 
           if [ "$CSPROJ_VERSION" != "$PACKAGE_VERSION" ]; then
             echo "Version mismatch: csproj=$CSPROJ_VERSION tag=$PACKAGE_VERSION"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,8 @@
+# This workflow publishes the client as a NuGet package
+# It is triggered by tag pushes matching vX.Y.Z or vX.Y.Z-beta or vX.Y.Z-rc.3 ...
+# It assumes the tag version matches the csproj version (modulo the leading "v" in the git tag)
+
+
 name: Release to NuGet
 
 on:
@@ -5,7 +10,6 @@ on:
     tags:
       - "v*.*.*" # Matches stable versions like v1.2.3
       - "v*.*.*-*" # Matches pre-release versions like v2.0.1-beta
-  workflow_dispatch:
 jobs:
   build-and-release:
     runs-on: ubuntu-latest
@@ -25,6 +29,15 @@ jobs:
           TAG=${{ github.ref_name }}
           VERSION=${TAG#v} # Removes 'v' prefix
           echo "PACKAGE_VERSION=$VERSION" >> $GITHUB_ENV
+
+      - name: Validate git tag version equals csproj version
+        run: |
+          CSPROJ_VERSION=$(grep -oPm1 "(?<=<Version>)[^<]+" src/DataStax.AstraDB.DataApi/DataStax.AstraDB.DataApi.csproj)
+
+          if [ "$CSPROJ_VERSION" != "$PACKAGE_VERSION" ]; then
+            echo "Version mismatch: csproj=$CSPROJ_VERSION tag=$PACKAGE_VERSION"
+            exit 1
+          fi
 
       - name: Restore dependencies
         run: dotnet restore ./src/DataStax.AstraDB.DataApi/

--- a/src/DataStax.AstraDB.DataApi/DataStax.AstraDB.DataApi.csproj
+++ b/src/DataStax.AstraDB.DataApi/DataStax.AstraDB.DataApi.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.2.0</Version>
+    <Version>2.2.0-rc.0</Version>
     <TargetFrameworks>net462;netstandard2.1;net8.0</TargetFrameworks>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>


### PR DESCRIPTION
This PR changes the client version in the csproj file to `2.2.0-rc.0`, which will then be released before the actual 2.2.0.

Moreover, and most important, some safety measures are enforced in the release workflow: namely,

1. Removed the possibility to manually dispatch the flow (only pushing a properly-formatted git tag would do). This is to prevent the flow from accidentally trying to publish a nonsense version such as a literal `main` to nuget;
2. Consistency check: if the git version (bereft of the leading "v") does not match the csproj version, the process errors and stops.
