### PR TITLE
Bump to version 2.2.0

### DIFF
--- a/src/DataStax.AstraDB.DataApi/DataStax.AstraDB.DataApi.csproj
+++ b/src/DataStax.AstraDB.DataApi/DataStax.AstraDB.DataApi.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.2.0-rc.0</Version>
+    <Version>2.2.0</Version>
     <TargetFrameworks>net462;netstandard2.1;net8.0</TargetFrameworks>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>


### PR DESCRIPTION
Now this is for releasing the actual `v2.2.0` c# client.