### PR TITLE
Admin enrichment: PCU Groups, CreateDatabase, plus some cleanup/tidiness

### DIFF
--- a/src/DataStax.AstraDB.DataApi/Admin/AstraDatabasesAdmin.cs
+++ b/src/DataStax.AstraDB.DataApi/Admin/AstraDatabasesAdmin.cs
@@ -17,6 +17,7 @@
 using DataStax.AstraDB.DataApi.Core;
 using DataStax.AstraDB.DataApi.Core.Commands;
 using DataStax.AstraDB.DataApi.Utils;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -37,6 +38,7 @@ public class AstraDatabasesAdmin
 {
     private readonly CommandOptions _adminOptions;
     private readonly DataAPIClient _client;
+    private readonly ILogger _logger;
 
     private CommandOptions[] OptionsTree => new CommandOptions[] { _client.ClientOptions, _adminOptions };
 
@@ -57,6 +59,7 @@ public class AstraDatabasesAdmin
         Guard.NotNull(client, nameof(client));
         _client = client;
         _adminOptions = adminOptions;
+        _logger = client.Logger;
     }
 
     internal string DevOpsAPISuffix(DBEnvironment? environment) => environment switch
@@ -166,6 +169,49 @@ public class AstraDatabasesAdmin
         Guard.NotNullOrEmpty(options.Name, nameof(options.Name));
         Guard.NotNull(options.CloudProvider, nameof(options.CloudProvider));
         Guard.NotNullOrEmpty(options.Region, nameof(options.Region));
+
+        if (options.PCUGroupId != null)
+        {
+            _logger.LogDebug("PCUGroupId specified ({PCUGroupId}): validating against available PCU groups.", options.PCUGroupId);
+            var listPCUOptions = ListPCUGroupsOptions.FromCommandOptions(options);
+            List<PCUGroup> pcuGroups = null;
+            try
+            {
+                pcuGroups = await ListPCUGroupsAsync(listPCUOptions, runSynchronously).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to retrieve PCU groups; skipping PCU group validation.");
+            }
+
+            if (pcuGroups != null)
+            {
+                _logger.LogDebug("Retrieved {Count} PCU group(s); searching for id={PCUGroupId}.", pcuGroups.Count, options.PCUGroupId);
+                var matchedGroup = pcuGroups.FirstOrDefault(g =>
+                    string.Equals(g.Id, options.PCUGroupId, StringComparison.OrdinalIgnoreCase));
+
+                if (matchedGroup == null)
+                {
+                    throw new InvalidOperationException(
+                        $"No PCU group with id '{options.PCUGroupId}' was found.");
+                }
+
+                _logger.LogDebug("Found PCU group '{PCUGroupId}': cloudProvider={CloudProvider}, region={Region}.", matchedGroup.Id, matchedGroup.CloudProvider, matchedGroup.Region);
+
+                bool cloudProviderMatches = matchedGroup.CloudProvider == options.CloudProvider;
+                bool regionMatches = string.Equals(matchedGroup.Region, options.Region, StringComparison.OrdinalIgnoreCase);
+
+                if (!cloudProviderMatches || !regionMatches)
+                {
+                    throw new InvalidOperationException(
+                        $"PCU group '{options.PCUGroupId}' is in cloudProvider={matchedGroup.CloudProvider}, region={matchedGroup.Region}, " +
+                        $"which does not match the requested cloudProvider={options.CloudProvider}, region={options.Region}.");
+                }
+
+                _logger.LogDebug("PCU group '{PCUGroupId}' validated successfully; proceeding with database creation.", options.PCUGroupId);
+            }
+        }
+
         Command command = CreateCommand()
             .AddUrlPath("databases")
             .WithPayload(options.ToPayload())

--- a/src/DataStax.AstraDB.DataApi/Admin/AstraDatabasesAdmin.cs
+++ b/src/DataStax.AstraDB.DataApi/Admin/AstraDatabasesAdmin.cs
@@ -407,6 +407,49 @@ public class AstraDatabasesAdmin
         return response;
     }
 
+    /// <summary>
+    /// Synchronous version of <see cref="ListPCUGroupsAsync(ListPCUGroupsOptions)"/>
+    /// </summary>
+    /// <inheritdoc cref="ListPCUGroupsAsync(ListPCUGroupsOptions)"/>
+    public List<PCUGroup> ListPCUGroups(ListPCUGroupsOptions options = null)
+    {
+        return ListPCUGroupsAsync(options, true).ResultSync();
+    }
+
+    /// <summary>
+    /// List the PCU (Provisioned Capacity Units) Groups pertaining to the current org.
+    /// </summary>
+    /// <param name="options">Additional options to the DevOps API query, such as cloud provider/region filters and general request execution parameters.</param>
+    /// <returns>A list of the PCU Groups according to the requested filtering.</returns>
+    public Task<List<PCUGroup>> ListPCUGroupsAsync(ListPCUGroupsOptions options = null)
+    {
+        return ListPCUGroupsAsync(options, false);
+    }
+
+    internal async Task<List<PCUGroup>> ListPCUGroupsAsync(ListPCUGroupsOptions options, bool runSynchronously)
+    {
+        if (options != null && (options.CloudProvider == null) != (options.Region == null))
+            throw new ArgumentException(
+                "Either both or none of CloudProvider and Region must be set for filtering PCU Groups.",
+                nameof(options));
+
+        var command = CreateCommand()
+            .AddUrlPath("pcus/actions/get")
+            .WithPayload(new Dictionary<string, string>())
+            .WithTimeoutManager(new DatabaseAdminTimeoutManager())
+            .AddCommandOptions(options);
+
+        var response = await command.RunAsyncRaw<List<PCUGroup>>(HttpMethod.Post, runSynchronously);
+        // apply cloud/region filter if required:
+        if (options?.CloudProvider == null)
+        {
+            return response;
+        }
+        return response
+            .Where(group => group.CloudProvider == options.CloudProvider && group.Region == options.Region)
+            .ToList();
+    }
+
     private DatabaseAdminAstra GetDatabaseAdmin(DatabaseInfo dbInfo, GetDatabaseAdminOptions options = null)
     {
         var commandOptions = CommandOptions.Merge(new CommandOptions[] {_adminOptions, options});

--- a/src/DataStax.AstraDB.DataApi/Admin/AstraDatabasesAdmin.cs
+++ b/src/DataStax.AstraDB.DataApi/Admin/AstraDatabasesAdmin.cs
@@ -172,7 +172,7 @@ public class AstraDatabasesAdmin
 
         if (options.PCUGroupId != null)
         {
-            _logger.LogDebug("PCUGroupId specified ({PCUGroupId}): validating against available PCU groups.", options.PCUGroupId);
+            _logger.LogInformation("PCUGroupId specified ({PCUGroupId}): validating against available PCU groups.", options.PCUGroupId);
             var listPCUOptions = ListPCUGroupsOptions.FromCommandOptions(options);
             List<PCUGroup> pcuGroups = null;
             try
@@ -186,29 +186,31 @@ public class AstraDatabasesAdmin
 
             if (pcuGroups != null)
             {
-                _logger.LogDebug("Retrieved {Count} PCU group(s); searching for id={PCUGroupId}.", pcuGroups.Count, options.PCUGroupId);
+                _logger.LogInformation("Retrieved {Count} PCU group(s); searching for id={PCUGroupId}.", pcuGroups.Count, options.PCUGroupId);
                 var matchedGroup = pcuGroups.FirstOrDefault(g =>
                     string.Equals(g.Id, options.PCUGroupId, StringComparison.OrdinalIgnoreCase));
 
                 if (matchedGroup == null)
                 {
+                    _logger.LogInformation("PCU group '{PCUGroupId}' was not found: aborting database creation.", options.PCUGroupId);
                     throw new InvalidOperationException(
                         $"No PCU group with id '{options.PCUGroupId}' was found.");
                 }
 
-                _logger.LogDebug("Found PCU group '{PCUGroupId}': cloudProvider={CloudProvider}, region={Region}.", matchedGroup.Id, matchedGroup.CloudProvider, matchedGroup.Region);
+                _logger.LogInformation("Found PCU group '{PCUGroupId}': cloudProvider={CloudProvider}, region={Region}.", matchedGroup.Id, matchedGroup.CloudProvider, matchedGroup.Region);
 
                 bool cloudProviderMatches = matchedGroup.CloudProvider == options.CloudProvider;
                 bool regionMatches = string.Equals(matchedGroup.Region, options.Region, StringComparison.OrdinalIgnoreCase);
 
                 if (!cloudProviderMatches || !regionMatches)
                 {
+                    _logger.LogInformation("PCU group '{PCUGroupId}' was found in a different region: aborting database creation.", matchedGroup.Id);
                     throw new InvalidOperationException(
                         $"PCU group '{options.PCUGroupId}' is in cloudProvider={matchedGroup.CloudProvider}, region={matchedGroup.Region}, " +
                         $"which does not match the requested cloudProvider={options.CloudProvider}, region={options.Region}.");
                 }
 
-                _logger.LogDebug("PCU group '{PCUGroupId}' validated successfully; proceeding with database creation.", options.PCUGroupId);
+                _logger.LogInformation("PCU group '{PCUGroupId}' validated successfully; proceeding with database creation.", options.PCUGroupId);
             }
         }
 

--- a/src/DataStax.AstraDB.DataApi/Admin/CloudProviderType.cs
+++ b/src/DataStax.AstraDB.DataApi/Admin/CloudProviderType.cs
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-// using System;
-// using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace DataStax.AstraDB.DataApi.Admin;
@@ -23,7 +21,6 @@ namespace DataStax.AstraDB.DataApi.Admin;
 /// <summary>
 /// Specifies the cloud provider on which an Astra DB database is deployed.
 /// </summary>
-// [JsonConverter(typeof(CloudProviderTypeConverter))]
 public enum CloudProviderType
 {
     /// <summary>Amazon Web Services.</summary>
@@ -36,27 +33,3 @@ public enum CloudProviderType
     [JsonStringEnumMemberName("azure")]
     AZURE
 }
-
-// internal sealed class CloudProviderTypeConverter : JsonConverter<CloudProviderType>
-// {
-//     public override CloudProviderType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-//     {
-//         var value = reader.GetString();
-//         if (string.Equals(value, "aws", StringComparison.OrdinalIgnoreCase)) return CloudProviderType.AWS;
-//         if (string.Equals(value, "gcp", StringComparison.OrdinalIgnoreCase)) return CloudProviderType.GCP;
-//         if (string.Equals(value, "azure", StringComparison.OrdinalIgnoreCase)) return CloudProviderType.AZURE;
-//         throw new JsonException($"Unknown CloudProviderType value: '{value}'");
-//     }
-
-//     public override void Write(Utf8JsonWriter writer, CloudProviderType value, JsonSerializerOptions options)
-//     {
-//         var serialized = value switch
-//         {
-//             CloudProviderType.AWS => "aws",
-//             CloudProviderType.GCP => "gcp",
-//             CloudProviderType.AZURE => "azure",
-//             _ => throw new JsonException($"Unknown CloudProviderType value: '{value}'")
-//         };
-//         writer.WriteStringValue(serialized);
-//     }
-// }

--- a/src/DataStax.AstraDB.DataApi/Admin/CloudProviderType.cs
+++ b/src/DataStax.AstraDB.DataApi/Admin/CloudProviderType.cs
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+// using System;
+// using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace DataStax.AstraDB.DataApi.Admin;
@@ -21,7 +23,7 @@ namespace DataStax.AstraDB.DataApi.Admin;
 /// <summary>
 /// Specifies the cloud provider on which an Astra DB database is deployed.
 /// </summary>
-[JsonConverter(typeof(JsonStringEnumConverter<CloudProviderType>))]
+// [JsonConverter(typeof(CloudProviderTypeConverter))]
 public enum CloudProviderType
 {
     /// <summary>Amazon Web Services.</summary>
@@ -32,5 +34,29 @@ public enum CloudProviderType
     GCP,
     /// <summary>Microsoft Azure.</summary>
     [JsonStringEnumMemberName("azure")]
-    Azure
+    AZURE
 }
+
+// internal sealed class CloudProviderTypeConverter : JsonConverter<CloudProviderType>
+// {
+//     public override CloudProviderType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+//     {
+//         var value = reader.GetString();
+//         if (string.Equals(value, "aws", StringComparison.OrdinalIgnoreCase)) return CloudProviderType.AWS;
+//         if (string.Equals(value, "gcp", StringComparison.OrdinalIgnoreCase)) return CloudProviderType.GCP;
+//         if (string.Equals(value, "azure", StringComparison.OrdinalIgnoreCase)) return CloudProviderType.AZURE;
+//         throw new JsonException($"Unknown CloudProviderType value: '{value}'");
+//     }
+
+//     public override void Write(Utf8JsonWriter writer, CloudProviderType value, JsonSerializerOptions options)
+//     {
+//         var serialized = value switch
+//         {
+//             CloudProviderType.AWS => "aws",
+//             CloudProviderType.GCP => "gcp",
+//             CloudProviderType.AZURE => "azure",
+//             _ => throw new JsonException($"Unknown CloudProviderType value: '{value}'")
+//         };
+//         writer.WriteStringValue(serialized);
+//     }
+// }

--- a/src/DataStax.AstraDB.DataApi/Admin/CreateDatabaseOptions.cs
+++ b/src/DataStax.AstraDB.DataApi/Admin/CreateDatabaseOptions.cs
@@ -25,6 +25,10 @@ namespace DataStax.AstraDB.DataApi.Admin;
 /// </summary>
 public class CreateDatabaseOptions : BlockingCommandOptions
 {
+    private const string DefaultTier = "serverless";
+    private const int DefaultCapacityUnits = 1;
+    private const string DefaultDbType = "vector";
+
     /// <summary>
     /// Name of the database to be created.
     /// </summary>
@@ -49,15 +53,33 @@ public class CreateDatabaseOptions : BlockingCommandOptions
         set => base.Keyspace = value;
     }
 
+    /// <summary>
+    /// Database tier (defaults to "serverless").
+    /// </summary>
+    public string Tier { get; set; } = DefaultTier;
+
+    /// <summary>
+    /// Capacity units for the database (defaults to 1).
+    /// </summary>
+    public int CapacityUnits { get; set; } = DefaultCapacityUnits;
+
+    /// <summary>
+    /// Database type (defaults to "vector").
+    /// </summary>
+    public string DBType { get; set; } = DefaultDbType;
+
+    /// <summary>
+    /// PCU group ID to use for provisioning the database. Optional.
+    /// </summary>
+    public string PCUGroupId { get; set; } = null;
+
     internal object ToPayload()
     {
         var payload = new Dictionary<string, object>();
 
-        // hardcoded properties
-        payload["tier"] = "serverless";
-        payload["capacityUnits"] = 1;
-        payload["dbType"] = "vector";
-        // specified properties
+        payload["tier"] = Tier;
+        payload["capacityUnits"] = CapacityUnits;
+        payload["dbType"] = DBType;
         if ( Name != null )
         {
             payload["name"] = Name;
@@ -73,6 +95,10 @@ public class CreateDatabaseOptions : BlockingCommandOptions
         if ( Keyspace != null )
         {
             payload["keyspace"] = Keyspace;
+        }
+        if ( PCUGroupId != null )
+        {
+            payload["pcuGroupUUID"] = PCUGroupId;
         }
 
         return payload;

--- a/src/DataStax.AstraDB.DataApi/Admin/CreateKeyspaceOptions.cs
+++ b/src/DataStax.AstraDB.DataApi/Admin/CreateKeyspaceOptions.cs
@@ -14,11 +14,17 @@
  * limitations under the License.
  */
 
-namespace DataStax.AstraDB.DataApi.Core;
+using DataStax.AstraDB.DataApi.Core;
+
+namespace DataStax.AstraDB.DataApi.Admin;
 
 /// <summary>
-/// Options specific to the database admin command to drop a keyspace.
+/// Options specific to the database admin command to create a keyspace.
 /// </summary>
-public class DropKeyspaceOptions : BlockingCommandOptions
+public class CreateKeyspaceOptions : BlockingCommandOptions
 {
+  /// <summary>
+  /// Whether to set the new keyspace as the active keyspace for the associated Database.
+  /// </summary>
+  public bool updateDBKeyspace { get; set; } = false;
 }

--- a/src/DataStax.AstraDB.DataApi/Admin/DoesKeyspaceExistOptions.cs
+++ b/src/DataStax.AstraDB.DataApi/Admin/DoesKeyspaceExistOptions.cs
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-namespace DataStax.AstraDB.DataApi.Core;
+using DataStax.AstraDB.DataApi.Core;
+
+namespace DataStax.AstraDB.DataApi.Admin;
 
 /// <summary>
 /// Command options specific to the database admin's DoesKeyspaceExist methods.

--- a/src/DataStax.AstraDB.DataApi/Admin/DropKeyspaceOptions.cs
+++ b/src/DataStax.AstraDB.DataApi/Admin/DropKeyspaceOptions.cs
@@ -14,15 +14,13 @@
  * limitations under the License.
  */
 
-namespace DataStax.AstraDB.DataApi.Core;
+using DataStax.AstraDB.DataApi.Core;
+
+namespace DataStax.AstraDB.DataApi.Admin;
 
 /// <summary>
-/// Options specific to the database admin command to create a keyspace.
+/// Options specific to the database admin command to drop a keyspace.
 /// </summary>
-public class CreateKeyspaceOptions : BlockingCommandOptions
+public class DropKeyspaceOptions : BlockingCommandOptions
 {
-  /// <summary>
-  /// Whether to set the new keyspace as the active keyspace for the associated Database.
-  /// </summary>
-  public bool updateDBKeyspace { get; set; } = false;
 }

--- a/src/DataStax.AstraDB.DataApi/Admin/ListKeyspacesOptions.cs
+++ b/src/DataStax.AstraDB.DataApi/Admin/ListKeyspacesOptions.cs
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-using DataStax.AstraDB.DataApi.Admin;
+using DataStax.AstraDB.DataApi.Core;
 
-namespace DataStax.AstraDB.DataApi.Core;
+namespace DataStax.AstraDB.DataApi.Admin;
 
 /// <summary>
 /// Command options specific to the database admin's ListKeyspaces methods.

--- a/src/DataStax.AstraDB.DataApi/Admin/ListPCUGroupsOptions.cs
+++ b/src/DataStax.AstraDB.DataApi/Admin/ListPCUGroupsOptions.cs
@@ -28,7 +28,7 @@ public class ListPCUGroupsOptions : CommandOptions
     /// If set, filters results to this cloud provider only.
     /// Either both or none of CloudProvider and Region must be set
     /// </summary>
-    public AstraDatabaseCloudProvider? CloudProvider { get; set; }
+    public CloudProviderType? CloudProvider { get; set; }
 
     /// <summary>
     /// If set, filters results to this region only.
@@ -48,7 +48,7 @@ public class ListPCUGroupsOptions : CommandOptions
     }
 
     static internal ListPCUGroupsOptions FromCommandOptions(
-        CommandOptions options, AstraDatabaseCloudProvider? cloudProvider = null, string region = null
+        CommandOptions options, CloudProviderType? cloudProvider = null, string region = null
     )
     {
         if (options == null) return null;

--- a/src/DataStax.AstraDB.DataApi/Admin/ListPCUGroupsOptions.cs
+++ b/src/DataStax.AstraDB.DataApi/Admin/ListPCUGroupsOptions.cs
@@ -1,0 +1,39 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using DataStax.AstraDB.DataApi.Core;
+
+namespace DataStax.AstraDB.DataApi.Admin;
+
+/// <summary>
+/// Options for AstraDatabasesAdmin's ListPCUGroups command.
+/// </summary>
+public class ListPCUGroupsOptions : CommandOptions
+{
+
+    /// <summary>
+    /// If set, filters results to this cloud provider only.
+    /// Either both or none of CloudProvider and Region must be set
+    /// </summary>
+    public AstraDatabaseCloudProvider? CloudProvider { get; set; }
+
+    /// <summary>
+    /// If set, filters results to this region only.
+    /// Either both or none of CloudProvider and Region must be set
+    /// </summary>
+    public string Region { get; set; }
+
+}

--- a/src/DataStax.AstraDB.DataApi/Admin/ListPCUGroupsOptions.cs
+++ b/src/DataStax.AstraDB.DataApi/Admin/ListPCUGroupsOptions.cs
@@ -36,4 +36,25 @@ public class ListPCUGroupsOptions : CommandOptions
     /// </summary>
     public string Region { get; set; }
 
+    internal ListPCUGroupsOptions(CommandOptions source) : base(source)
+    {
+    }
+
+    /// <summary>
+    /// Creates a new instance of <see cref="ListPCUGroupsOptions"/> with default values.
+    /// </summary>
+    public ListPCUGroupsOptions() : base()
+    {
+    }
+
+    static internal ListPCUGroupsOptions FromCommandOptions(
+        CommandOptions options, AstraDatabaseCloudProvider? cloudProvider = null, string region = null
+    )
+    {
+        if (options == null) return null;
+        return new ListPCUGroupsOptions(options) {
+            CloudProvider = cloudProvider, Region = region
+        };
+    }
+
 }

--- a/src/DataStax.AstraDB.DataApi/Admin/PCUGroup.cs
+++ b/src/DataStax.AstraDB.DataApi/Admin/PCUGroup.cs
@@ -16,7 +16,6 @@
 
 using System;
 using System.Text.Json.Serialization;
-using DataStax.AstraDB.DataApi.SerDes;
 
 namespace DataStax.AstraDB.DataApi.Admin;
 
@@ -50,7 +49,6 @@ public class PCUGroup
     /// The cloud provider for this PCU group (e.g. 'AWS').
     /// </summary>
     [JsonPropertyName("cloudProvider")]
-    [JsonConverter(typeof(CloudProviderTypeConverter))]
     public CloudProviderType? CloudProvider { get; set; }
 
     /// <summary>
@@ -165,7 +163,6 @@ public class PCUType
     /// </summary>
     [JsonPropertyName("provider")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    [JsonConverter(typeof(CloudProviderTypeConverter))]
     public CloudProviderType? CloudProvider { get; set; }
 
     /// <summary>

--- a/src/DataStax.AstraDB.DataApi/Admin/PCUGroup.cs
+++ b/src/DataStax.AstraDB.DataApi/Admin/PCUGroup.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Text.Json.Serialization;
+using DataStax.AstraDB.DataApi.SerDes;
 
 namespace DataStax.AstraDB.DataApi.Admin;
 
@@ -49,7 +50,7 @@ public class PCUGroup
     /// The cloud provider for this PCU group (e.g. 'AWS').
     /// </summary>
     [JsonPropertyName("cloudProvider")]
-    [JsonConverter(typeof(JsonStringEnumConverter))]
+    [JsonConverter(typeof(CloudProviderTypeConverter))]
     public CloudProviderType? CloudProvider { get; set; }
 
     /// <summary>
@@ -164,7 +165,7 @@ public class PCUType
     /// </summary>
     [JsonPropertyName("provider")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    [JsonConverter(typeof(JsonStringEnumConverter))]
+    [JsonConverter(typeof(CloudProviderTypeConverter))]
     public CloudProviderType? CloudProvider { get; set; }
 
     /// <summary>

--- a/src/DataStax.AstraDB.DataApi/Admin/PCUGroup.cs
+++ b/src/DataStax.AstraDB.DataApi/Admin/PCUGroup.cs
@@ -1,0 +1,204 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using DataStax.AstraDB.DataApi.Core;
+using System;
+using System.Text.Json.Serialization;
+
+namespace DataStax.AstraDB.DataApi.Admin;
+
+/// <summary>
+/// The specifications for a PCU (Provisioned Capacity Unit) group,
+/// such as the ones returned when querying the DevOps API for PCU groups.
+/// </summary>
+public class PCUGroup
+{
+    /// <summary>
+    /// The unique identifier for the PCU group (a UUID as a string).
+    /// </summary>
+    [JsonPropertyName("uuid")]
+    public string Id { get; set; }
+
+    /// <summary>
+    /// The organization ID this PCU group belongs to.
+    /// </summary>
+    [JsonPropertyName("orgId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string OrgId { get; set; }
+
+    /// <summary>
+    /// The title (name) of the PCU group.
+    /// </summary>
+    [JsonPropertyName("title")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string Title { get; set; }
+
+    /// <summary>
+    /// The cloud provider for this PCU group (e.g. 'AWS').
+    /// </summary>
+    [JsonPropertyName("cloudProvider")]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public AstraDatabaseCloudProvider? CloudProvider { get; set; }
+
+    /// <summary>
+    /// The region this PCU group is ascribed to.
+    /// </summary>
+    [JsonPropertyName("region")]
+    public string Region { get; set; }
+
+    /// <summary>
+    /// The instance type for this PCU group.
+    /// </summary>
+    [JsonPropertyName("instanceType")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string InstanceType { get; set; }
+
+    /// <summary>
+    /// The PCU type descriptor.
+    /// </summary>
+    [JsonPropertyName("pcuType")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public PCUType PCUType { get; set; }
+
+    /// <summary>
+    /// The provisioning type (e.g. 'shared').
+    /// </summary>
+    [JsonPropertyName("provisionType")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string ProvisionType { get; set; }
+
+    /// <summary>
+    /// The minimum shared hourly PCUs in the group.
+    /// </summary>
+    [JsonPropertyName("min")]
+    public int Min { get; set; }
+
+    /// <summary>
+    /// The maximum shared hourly PCUs in the group.
+    /// </summary>
+    [JsonPropertyName("max")]
+    public int Max { get; set; }
+
+    /// <summary>
+    /// The absolute required PCUs in the group.
+    /// </summary>
+    [JsonPropertyName("reserved")]
+    public int Reserved { get; set; }
+
+    /// <summary>
+    /// A description of the PCU group.
+    /// </summary>
+    [JsonPropertyName("description")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string Description { get; set; }
+
+    /// <summary>
+    /// Creation time of the PCU group.
+    /// </summary>
+    [JsonPropertyName("createdAt")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public DateTime? CreatedAt { get; set; }
+
+    /// <summary>
+    /// Update time of the PCU group.
+    /// </summary>
+    [JsonPropertyName("updatedAt")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public DateTime? UpdatedAt { get; set; }
+
+    /// <summary>
+    /// Identifier of the user who created the PCU group.
+    /// </summary>
+    [JsonPropertyName("createdBy")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string CreatedBy { get; set; }
+
+    /// <summary>
+    /// Identifier of the user who updated the PCU group.
+    /// </summary>
+    [JsonPropertyName("updatedBy")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string UpdatedBy { get; set; }
+
+    /// <summary>
+    /// The current status of the PCU group (e.g. 'INITIALIZING').
+    /// </summary>
+    [JsonPropertyName("status")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string Status { get; set; }
+}
+
+/// <summary>
+///  A PCU (Provisioned Capacity Unit) group type descriptor,
+///  describing a specific PCU configuration available in a region.
+/// </summary>
+public class PCUType
+{
+    /// <summary>
+    /// The type of PCU group (e.g. 'standard').
+    /// </summary>
+    [JsonPropertyName("type")]
+    public string Type { get; set; }
+
+    /// <summary>
+    /// The region where this PCU type is available.
+    /// </summary>
+    [JsonPropertyName("region")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string Region { get; set; }
+
+    /// <summary>
+    /// The cloud provider for this PCU type (e.g. 'AWS').
+    /// </summary>
+    [JsonPropertyName("provider")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public AstraDatabaseCloudProvider? CloudProvider { get; set; }
+
+    /// <summary>
+    /// Hardware specifications for this PCU type.
+    /// </summary>
+    [JsonPropertyName("details")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public PCUTypeDetails Details { get; set; }
+}
+
+/// <summary>
+/// The details of a PCU (Provisioned Capacity Unit) group type,
+/// describing the hardware specifications for a particular PCU configuration.
+/// </summary>
+public class PCUTypeDetails
+{
+    /// <summary>
+    /// The number of virtual CPUs for this PCU type.
+    /// </summary>
+    [JsonPropertyName("vCPU")]
+    public int VCpu { get; set; }
+
+    /// <summary>
+    /// The amount of memory for this PCU type.
+    /// </summary>
+    [JsonPropertyName("memory")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string Memory { get; set; }
+
+    /// <summary>
+    /// The amount of disk cache for this PCU type.
+    /// </summary>
+    [JsonPropertyName("disk_cache")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string DiskCache { get; set; }
+}

--- a/src/DataStax.AstraDB.DataApi/Admin/PCUGroup.cs
+++ b/src/DataStax.AstraDB.DataApi/Admin/PCUGroup.cs
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-using DataStax.AstraDB.DataApi.Core;
 using System;
 using System.Text.Json.Serialization;
 
@@ -51,7 +50,7 @@ public class PCUGroup
     /// </summary>
     [JsonPropertyName("cloudProvider")]
     [JsonConverter(typeof(JsonStringEnumConverter))]
-    public AstraDatabaseCloudProvider? CloudProvider { get; set; }
+    public CloudProviderType? CloudProvider { get; set; }
 
     /// <summary>
     /// The region this PCU group is ascribed to.
@@ -166,7 +165,7 @@ public class PCUType
     [JsonPropertyName("provider")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonConverter(typeof(JsonStringEnumConverter))]
-    public AstraDatabaseCloudProvider? CloudProvider { get; set; }
+    public CloudProviderType? CloudProvider { get; set; }
 
     /// <summary>
     /// Hardware specifications for this PCU type.

--- a/src/DataStax.AstraDB.DataApi/Admin/RegionInfo.cs
+++ b/src/DataStax.AstraDB.DataApi/Admin/RegionInfo.cs
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-using DataStax.AstraDB.DataApi.Admin;
+using DataStax.AstraDB.DataApi.Core;
 using System;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
-namespace DataStax.AstraDB.DataApi.Core;
+namespace DataStax.AstraDB.DataApi.Admin;
 
 /// <summary>
 /// The metadata information for a region.
@@ -73,4 +73,10 @@ public class RegionInfo
     /// </summary>
     [JsonPropertyName("zone")]
     public string Zone { get; set; }
+
+    /// <summary>
+    /// The types of PCU (Provisioned Capacity Units) available for this region.
+    /// </summary>
+    [JsonPropertyName("pcu_types")]
+    public List<PCUType> PCUTypes { get; set; }
 }

--- a/src/DataStax.AstraDB.DataApi/Core/Commands/Command.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/Commands/Command.cs
@@ -294,6 +294,8 @@ internal class Command
         {
             deserializeOptions.Converters.Add(new SimpleDictionaryConverter());
         }
+        deserializeOptions.Converters.Add(new CloudProviderTypeConverter());
+        deserializeOptions.Converters.Add(new CloudProviderTypeNullableConverter());
         deserializeOptions.Converters.Add(new IpAddressConverter());
         deserializeOptions.Converters.Add(new AnalyzerOptionsConverter());
 

--- a/src/DataStax.AstraDB.DataApi/Core/DatabaseInfo.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/DatabaseInfo.cs
@@ -32,7 +32,7 @@ public class DatabaseInfo
         OrgId = rawInfo.OrgId;
         OwnerId = rawInfo.OwnerId;
         Status = Enum.TryParse<AstraDatabaseStatus>(rawInfo.Status, true, out var status) ? status : AstraDatabaseStatus.UNKNOWN;
-        CloudProvider = Enum.TryParse<AstraDatabaseCloudProvider>(rawInfo.Info.CloudProvider, true, out var cloudProvider) ? cloudProvider : AstraDatabaseCloudProvider.AWS;
+        CloudProvider = Enum.TryParse<CloudProviderType>(rawInfo.Info.CloudProvider, true, out var cloudProvider) ? cloudProvider : CloudProviderType.AWS;
         CreatedAt = rawInfo.CreationTime;
         LastUsed = rawInfo.LastUsageTime;
         Keyspaces = rawInfo.Info.Keyspaces;
@@ -51,7 +51,7 @@ public class DatabaseInfo
     /// <summary>The current lifecycle status of the database.</summary>
     public AstraDatabaseStatus Status { get; set; }
     /// <summary>The cloud provider where the database is deployed.</summary>
-    public AstraDatabaseCloudProvider CloudProvider { get; set; }
+    public CloudProviderType CloudProvider { get; set; }
     /// <summary>The date and time when the database was created.</summary>
     public DateTime CreatedAt { get; set; }
     /// <summary>The date and time when the database was last used.</summary>
@@ -77,19 +77,6 @@ public class AstraDatabaseRegionInfo
     public DateTime CreatedAt { get; set; }
     /// <summary>The name of the region.</summary>
     public string Name { get; set; }
-}
-
-/// <summary>
-/// The cloud provider where an Astra database is deployed.
-/// </summary>
-public enum AstraDatabaseCloudProvider
-{
-    /// <summary>Amazon Web Services.</summary>
-    AWS,
-    /// <summary>Google Cloud Platform.</summary>
-    GCP,
-    /// <summary>Microsoft Azure.</summary>
-    AZURE
 }
 
 /// <summary>

--- a/src/DataStax.AstraDB.DataApi/Core/UserDefinedTypeField.cs
+++ b/src/DataStax.AstraDB.DataApi/Core/UserDefinedTypeField.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace DataStax.AstraDB.DataApi.Core;
 
 /// <summary>

--- a/src/DataStax.AstraDB.DataApi/SerDes/CloudProviderTypeConverter.cs
+++ b/src/DataStax.AstraDB.DataApi/SerDes/CloudProviderTypeConverter.cs
@@ -1,0 +1,78 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using DataStax.AstraDB.DataApi.Admin;
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace DataStax.AstraDB.DataApi.SerDes;
+
+
+/// <summary>
+/// JSON converter for <see cref="CloudProviderType"/>, with case-insensitive deserialization logic.
+/// </summary>
+public class CloudProviderTypeConverter : JsonConverter<CloudProviderType>
+{
+    /// <summary>
+    /// Reads and converts values into a <see cref="CloudProviderType"/>, case-insensitively.
+    /// </summary>
+    public override CloudProviderType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        var value = reader.GetString();
+        if (string.Equals(value, "aws", StringComparison.OrdinalIgnoreCase)) return CloudProviderType.AWS;
+        if (string.Equals(value, "gcp", StringComparison.OrdinalIgnoreCase)) return CloudProviderType.GCP;
+        if (string.Equals(value, "azure", StringComparison.OrdinalIgnoreCase)) return CloudProviderType.AZURE;
+        throw new JsonException($"Unknown CloudProviderType value: '{value}'");
+    }
+
+    /// <summary>
+    /// Writes an <see cref="CloudProviderType"/> value as string.
+    /// </summary>
+    public override void Write(Utf8JsonWriter writer, CloudProviderType value, JsonSerializerOptions options)
+    {
+        var serialized = value switch
+        {
+            CloudProviderType.AWS => "aws",
+            CloudProviderType.GCP => "gcp",
+            CloudProviderType.AZURE => "azure",
+            _ => throw new JsonException($"Unknown CloudProviderType value: '{value}'")
+        };
+        writer.WriteStringValue(serialized);
+    }
+}
+
+/// <summary>
+/// JSON converter for <see cref="CloudProviderType"/>?, with case-insensitive deserialization logic.
+/// </summary>
+public class CloudProviderTypeNullableConverter : JsonConverter<CloudProviderType?>
+{
+    private static readonly CloudProviderTypeConverter _inner = new();
+
+    /// <inheritdoc/>
+    public override CloudProviderType? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.Null) return null;
+        return _inner.Read(ref reader, typeof(CloudProviderType), options);
+    }
+
+    /// <inheritdoc/>
+    public override void Write(Utf8JsonWriter writer, CloudProviderType? value, JsonSerializerOptions options)
+    {
+        if (value is null) { writer.WriteNullValue(); return; }
+        _inner.Write(writer, value.Value, options);
+    }
+}

--- a/src/DataStax.AstraDB.DataApi/Tables/DropUserDefinedTypeRequest.cs
+++ b/src/DataStax.AstraDB.DataApi/Tables/DropUserDefinedTypeRequest.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 

--- a/src/DataStax.AstraDB.DataApi/Utils/DeserializationUtils.cs
+++ b/src/DataStax.AstraDB.DataApi/Utils/DeserializationUtils.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 using System.Linq;
 using System.Text.Json;

--- a/src/DataStax.AstraDB.DataApi/Utils/TypeUtilities.cs
+++ b/src/DataStax.AstraDB.DataApi/Utils/TypeUtilities.cs
@@ -1,4 +1,18 @@
-
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 using DataStax.AstraDB.DataApi.Core;
 using DataStax.AstraDB.DataApi.Tables;

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/AssemblyInfo.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/AssemblyInfo.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Xunit;
 
 [assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Constants.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Constants.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 namespace DataStax.AstraDB.DataApi.IntegrationTests;
 

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/FileLogger.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/FileLogger.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.Logging;
 
 namespace DataStax.AstraDB.DataApi.IntegrationTests;

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Fixtures/AdminFixture.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Fixtures/AdminFixture.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using DataStax.AstraDB.DataApi.Admin;
 using DataStax.AstraDB.DataApi.Core;
 using System.Text.RegularExpressions;

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Fixtures/AssemblyFixture.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Fixtures/AssemblyFixture.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using DataStax.AstraDB.DataApi.Admin;
 using DataStax.AstraDB.DataApi.Core;
 using Microsoft.Extensions.Configuration;

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Fixtures/BaseFixture.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Fixtures/BaseFixture.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using DataStax.AstraDB.DataApi.Core;
 using Microsoft.Extensions.Logging;
 

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Fixtures/CollectionCursorFixture.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Fixtures/CollectionCursorFixture.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using DataStax.AstraDB.DataApi.Collections;
 using DataStax.AstraDB.DataApi.Core;
 using DataStax.AstraDB.DataApi.Core.Query;

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Fixtures/CollectionFARRCursorFixture.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Fixtures/CollectionFARRCursorFixture.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using DataStax.AstraDB.DataApi.Collections;
 using DataStax.AstraDB.DataApi.Core;
 using DataStax.AstraDB.DataApi.Core.Query;

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Fixtures/CollectionsFixture.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Fixtures/CollectionsFixture.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using DataStax.AstraDB.DataApi.Collections;
 using DataStax.AstraDB.DataApi.Core;
 using Xunit;

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Fixtures/DatabaseFixture.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Fixtures/DatabaseFixture.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using DataStax.AstraDB.DataApi.Core;
 using Xunit;
 

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Fixtures/FindAndUpdateFixture.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Fixtures/FindAndUpdateFixture.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using DataStax.AstraDB.DataApi.Collections;
 using DataStax.AstraDB.DataApi.Core;
 using Xunit;

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Fixtures/ReplaceAndDeleteFixture.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Fixtures/ReplaceAndDeleteFixture.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using DataStax.AstraDB.DataApi.Collections;
 using DataStax.AstraDB.DataApi.Core;
 using Xunit;

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Fixtures/SkipWhenAstraAttribute.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Fixtures/SkipWhenAstraAttribute.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.Configuration;
 using System.Reflection;
 using Xunit.v3;

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Fixtures/SkipWhenNotAstraAttribute.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Fixtures/SkipWhenNotAstraAttribute.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using Microsoft.Extensions.Configuration;
 using System.Reflection;
 using Xunit.v3;

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Fixtures/TableAlterFixture.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Fixtures/TableAlterFixture.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using DataStax.AstraDB.DataApi.Core;
 using DataStax.AstraDB.DataApi.Tables;
 using Xunit;

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Fixtures/TableIndexesFixture.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Fixtures/TableIndexesFixture.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using DataStax.AstraDB.DataApi.Core;
 using DataStax.AstraDB.DataApi.Tables;
 using Xunit;

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Fixtures/TablesFixture.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Fixtures/TablesFixture.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using DataStax.AstraDB.DataApi.Core;
 using DataStax.AstraDB.DataApi.Tables;
 using DataStax.AstraDB.DataApi.Utils;

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Fixtures/UpdatesFixture.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Fixtures/UpdatesFixture.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using DataStax.AstraDB.DataApi.Collections;
 using DataStax.AstraDB.DataApi.Core;
 using Xunit;

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Fixtures/UserDefinedTypesFixture.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Fixtures/UserDefinedTypesFixture.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using DataStax.AstraDB.DataApi.Core;
 using DataStax.AstraDB.DataApi.Tables;
 using Xunit;

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/TestObjects.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/TestObjects.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using DataStax.AstraDB.DataApi.Collections;
 using DataStax.AstraDB.DataApi.Core;
 using DataStax.AstraDB.DataApi.SerDes;

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdditionalCollectionTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdditionalCollectionTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using DataStax.AstraDB.DataApi.Collections;
 using DataStax.AstraDB.DataApi.Core;
 using DataStax.AstraDB.DataApi.Core.Query;

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdditionalTableTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdditionalTableTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using DataStax.AstraDB.DataApi.Core;
 using DataStax.AstraDB.DataApi.Core.Commands;
 using DataStax.AstraDB.DataApi.Core.Query;

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdminTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdminTests.cs
@@ -556,6 +556,37 @@ public class AdminTests
     }
 
     [SkipWhenNotAstra]
+    [Fact(Skip="Run manually when an ORG ADMIN token is used, or this endpoint will error")]
+    public async Task DatabaseAdminAstra_GetPCUGroups()
+    {
+        var admin = fixture.Client.GetAstraDatabasesAdmin();
+
+        var pcuGroupsFull = await admin.ListPCUGroupsAsync();
+        Assert.NotNull(pcuGroupsFull);
+
+        var pcuGroupsFiltered = await admin.ListPCUGroupsAsync(new ListPCUGroupsOptions {
+            CloudProvider = AstraDatabaseCloudProvider.AWS,
+            Region = "us-west-1"
+        });
+        Assert.NotNull(pcuGroupsFiltered);
+
+        Assert.True(pcuGroupsFull.Count >= pcuGroupsFiltered.Count);
+
+        // bad filtering patterns
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => admin.ListPCUGroupsAsync(new ListPCUGroupsOptions {
+                Region = "us-west-1"
+            })
+        );
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => admin.ListPCUGroupsAsync(new ListPCUGroupsOptions {
+                CloudProvider = AstraDatabaseCloudProvider.GCP
+            })
+        );
+
+    }
+
+    [SkipWhenNotAstra]
     [Fact()]
     public void CreateDatabaseMissingParameters()
     {

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdminTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdminTests.cs
@@ -728,6 +728,82 @@ public class AdminTests
         Assert.NotNull(tableNames);
     }
 
+    // dotnet test --filter FullyQualifiedName=DataStax.AstraDB.DataApi.IntegrationTests.AdminTests.CreateDatabaseBadPCUGroupNonblockingAsync
+    // ENSURE THE TOKEN CAN READ PCU GROUPS FOR THIS TEST (else you'll get another failure and test will fail)
+    [Fact(Skip = AdminCollection.SkipMessage)]
+    public async Task CreateDatabaseBadPCUGroupNonblockingAsync()
+    {
+        var dbName = "test-db-badpcugroup-create-async-x";
+        var creationOptions = new CreateDatabaseOptions() {
+            Name = dbName,
+            CloudProvider = CloudProviderType.AWS,
+            Region = "us-west-2",
+            waitForCompletion = false,
+            PCUGroupId = "bad_group_id",
+        };
+
+        var astraAdmin = fixture.Client.GetAstraDatabasesAdmin();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        {
+            await astraAdmin.CreateDatabaseAsync(creationOptions);
+        });
+    }
+
+    // dotnet test --filter FullyQualifiedName=DataStax.AstraDB.DataApi.IntegrationTests.AdminTests.CreateDatabaseMisplacedPCUGroupNonblockingAsync
+    // ENSURE THE TOKEN CAN READ PCU GROUPS FOR THIS TEST (else you'll get another failure and test will fail)
+    [Fact(Skip = AdminCollection.SkipMessage)]
+    public async Task CreateDatabaseMisplacedPCUGroupNonblockingAsync()
+    {
+        var dbName = "test-db-misplacedpcugroup-create-async-x";
+        // Manually ensure the PCU Group ID exists, but for another provider/region!
+        var creationOptions = new CreateDatabaseOptions() {
+            Name = dbName,
+            CloudProvider = CloudProviderType.GCP,
+            Region = "us-east1",
+            waitForCompletion = false,
+            PCUGroupId = "8424aa7c-a26b-44cc-8ae3-c65aec7a184f",
+        };
+
+        var astraAdmin = fixture.Client.GetAstraDatabasesAdmin();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        {
+            await astraAdmin.CreateDatabaseAsync(creationOptions);
+        });
+    }
+
+    // dotnet test --filter FullyQualifiedName=DataStax.AstraDB.DataApi.IntegrationTests.AdminTests.CreateDatabaseCorrectPCUGroupNonblockingAsync
+    // ENSURE THE TOKEN CAN READ PCU GROUPS FOR THIS TEST (else you'll get another failure and test will fail)
+    [Fact(Skip = AdminCollection.SkipMessage)]
+    public async Task CreateDatabaseCorrectPCUGroupNonblockingAsync()
+    {
+        var dbName = "test-db-correctpcugroup-create-async-x";
+        // Manually ensure the PCU Group ID exists, but for another provider/region!
+        var creationOptions = new CreateDatabaseOptions() {
+            Name = dbName,
+            CloudProvider = CloudProviderType.AWS,
+            Region = "us-west-2",
+            waitForCompletion = false,
+            PCUGroupId = "8424aa7c-a26b-44cc-8ae3-c65aec7a184f",
+        };
+
+        var astraAdmin = fixture.Client.GetAstraDatabasesAdmin();
+
+        var dbAdmin = await astraAdmin.CreateDatabaseAsync(creationOptions);
+
+        var dbStatus = await astraAdmin.GetDatabaseStatusAsync(dbAdmin.Id);
+        Assert.True(dbStatus == AstraDatabaseStatus.ASSOCIATING
+            || dbStatus == AstraDatabaseStatus.INITIALIZING
+            || dbStatus == AstraDatabaseStatus.PENDING);
+
+        var dbAdmin2 = astraAdmin.GetDatabaseAdmin(dbAdmin.GetAPIEndpoint());
+        var dbStatus2 = await astraAdmin.GetDatabaseStatusAsync(dbAdmin2.Id);
+        Assert.True(dbStatus2 == AstraDatabaseStatus.ASSOCIATING
+            || dbStatus2 == AstraDatabaseStatus.INITIALIZING
+            || dbStatus2 == AstraDatabaseStatus.PENDING);
+    }
+
     // dotnet test --filter FullyQualifiedName=DataStax.AstraDB.DataApi.IntegrationTests.AdminTests.DropDatabaseNonblockingSync
     [Fact(Skip = AdminCollection.SkipMessage)]
     public void DropDatabaseNonblockingSync()

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdminTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdminTests.cs
@@ -647,8 +647,8 @@ public class AdminTests
         var admin = fixture.Client.GetAstraDatabasesAdmin().CreateDatabase(
             new (){
                 Name = dbName,
-                CloudProvider = CloudProviderType.GCP,
-                Region = "europe-west4",
+                CloudProvider = CloudProviderType.AWS,
+                Region = "us-west-2",
                 Keyspace = "fedault_seykpace",
                 waitForCompletion = false,
             }

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdminTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdminTests.cs
@@ -546,6 +546,13 @@ public class AdminTests
         Assert.NotEmpty(regionsAll);
 
         Assert.True(regionsAll.Count >= regionsOnly.Count);
+
+        // region PCU information checks
+        Assert.NotEmpty(regionsDefault[0].PCUTypes);
+        var pcu_type = regionsDefault[0].PCUTypes[0];
+        Assert.IsType<PCUType>(pcu_type);
+        Assert.IsType<string>(pcu_type.Type);
+        Assert.IsType<PCUTypeDetails>(pcu_type.Details);
     }
 
     [SkipWhenNotAstra]

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdminTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdminTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using DataStax.AstraDB.DataApi.Admin;
 using DataStax.AstraDB.DataApi.Core;
 using DataStax.AstraDB.DataApi.Core.Results;

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdminTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdminTests.cs
@@ -565,7 +565,7 @@ public class AdminTests
         Assert.NotNull(pcuGroupsFull);
 
         var pcuGroupsFiltered = await admin.ListPCUGroupsAsync(new ListPCUGroupsOptions {
-            CloudProvider = AstraDatabaseCloudProvider.AWS,
+            CloudProvider = CloudProviderType.AWS,
             Region = "us-west-1"
         });
         Assert.NotNull(pcuGroupsFiltered);
@@ -580,7 +580,7 @@ public class AdminTests
         );
         await Assert.ThrowsAsync<ArgumentException>(
             () => admin.ListPCUGroupsAsync(new ListPCUGroupsOptions {
-                CloudProvider = AstraDatabaseCloudProvider.GCP
+                CloudProvider = CloudProviderType.GCP
             })
         );
 

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/CollectionCursorTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/CollectionCursorTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using DataStax.AstraDB.DataApi.Collections;
 using DataStax.AstraDB.DataApi.Core;
 using DataStax.AstraDB.DataApi.Core.Commands;

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/CollectionFARRCursorTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/CollectionFARRCursorTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using DataStax.AstraDB.DataApi.Collections;
 using DataStax.AstraDB.DataApi.Core;
 using DataStax.AstraDB.DataApi.Core.Commands;

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/CollectionTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/CollectionTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using DataStax.AstraDB.DataApi.Collections;
 using DataStax.AstraDB.DataApi.Core;
 using DataStax.AstraDB.DataApi.Core.Commands;

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/DatabaseTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/DatabaseTests.cs
@@ -1,3 +1,20 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using DataStax.AstraDB.DataApi.Admin;
 using DataStax.AstraDB.DataApi.Collections;
 using DataStax.AstraDB.DataApi.Core;
 using DataStax.AstraDB.DataApi.Core.Commands;

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/ExamplesTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/ExamplesTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using DataStax.AstraDB.DataApi.Collections;
 using DataStax.AstraDB.DataApi.Core;
 using DataStax.AstraDB.DataApi.IntegrationTests.Fixtures;

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/FindAndUpdateTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/FindAndUpdateTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using DataStax.AstraDB.DataApi.Core;
 using DataStax.AstraDB.DataApi.Core.Query;
 using DataStax.AstraDB.DataApi.IntegrationTests.Fixtures;

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/ReplaceAndDeleteTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/ReplaceAndDeleteTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using DataStax.AstraDB.DataApi.Collections;
 using DataStax.AstraDB.DataApi.Core;
 using DataStax.AstraDB.DataApi.Core.Query;

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/SearchTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/SearchTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using DataStax.AstraDB.DataApi.Collections;
 using DataStax.AstraDB.DataApi.Core;
 using DataStax.AstraDB.DataApi.Core.Query;

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/SerializationTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/SerializationTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using DataStax.AstraDB.DataApi.Collections;
 using DataStax.AstraDB.DataApi.Core;
 using DataStax.AstraDB.DataApi.Core.Commands;

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/TableAlterTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/TableAlterTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using DataStax.AstraDB.DataApi.Core;
 using DataStax.AstraDB.DataApi.IntegrationTests.Fixtures;
 using DataStax.AstraDB.DataApi.Tables;

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/TableIndexesTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/TableIndexesTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using DataStax.AstraDB.DataApi.Collections;
 using DataStax.AstraDB.DataApi.Core;
 using DataStax.AstraDB.DataApi.Core.Commands;

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/TableTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/TableTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using DataStax.AstraDB.DataApi.Core;
 using DataStax.AstraDB.DataApi.Core.Query;
 using DataStax.AstraDB.DataApi.Core.Results;

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/UpdateTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/UpdateTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using DataStax.AstraDB.DataApi.Collections;
 using DataStax.AstraDB.DataApi.Core;
 using DataStax.AstraDB.DataApi.Core.Query;

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/UserDefinedTypesTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/UserDefinedTypesTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using DataStax.AstraDB.DataApi.Core;
 using DataStax.AstraDB.DataApi.Core.Query;
 using DataStax.AstraDB.DataApi.IntegrationTests.Fixtures;

--- a/test/DataStax.AstraDB.DataApi.UnitTests/CollectionFindAndRerankOptionsTests.cs
+++ b/test/DataStax.AstraDB.DataApi.UnitTests/CollectionFindAndRerankOptionsTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using DataStax.AstraDB.DataApi.Core;
 using DataStax.AstraDB.DataApi.Collections;
 using DataStax.AstraDB.DataApi.Core.Query;

--- a/test/DataStax.AstraDB.DataApi.UnitTests/CommandOptionsTests.cs
+++ b/test/DataStax.AstraDB.DataApi.UnitTests/CommandOptionsTests.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 using DataStax.AstraDB.DataApi.Core;
 
 namespace DataStax.AstraDB.DataApi.Tests;

--- a/test/DataStax.AstraDB.DataApi.UnitTests/PCUGroupDeserializationTests.cs
+++ b/test/DataStax.AstraDB.DataApi.UnitTests/PCUGroupDeserializationTests.cs
@@ -1,0 +1,140 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using DataStax.AstraDB.DataApi.Admin;
+using DataStax.AstraDB.DataApi.Core;
+using DataStax.AstraDB.DataApi.Core.Commands;
+using Xunit;
+
+namespace DataStax.AstraDB.DataApi.UnitTests;
+
+
+public class PCUGroupDeserializationTests
+{
+    [Fact]
+    public void FullPCUGroupDeserializationTest()
+    {
+        var json = """
+            [
+                {
+                    "uuid": "9aaddbb5-4622-447c-9bc5-b036bb9d7ed8",
+                    "orgId": "org-id",
+                    "title": "some title",
+                    "cloudProvider": "AWS",
+                    "region": "us-east-1",
+                    "instanceType": "standard",
+                    "pcuType": {
+                        "type": "standard",
+                        "region": "eu-west-1",
+                        "provider": "aws",
+                        "details": {
+                            "vCPU": 0,
+                            "memory": "mstring",
+                            "disk_cache": "dcstring"
+                        }
+                    },
+                    "provisionType": "shared",
+                    "min": 1,
+                    "max": 1,
+                    "reserved": 1,
+                    "description": "some description",
+                    "createdAt": "2021-06-01T12:00:00.000Z",
+                    "updatedAt": "2021-06-01T12:00:00.000Z",
+                    "createdBy": "user",
+                    "updatedBy": "user",
+                    "status": "INITIALIZING"
+                }
+            ]
+        """;
+
+        // same deserialization setup as in the devops for AstraDatabasesAdmin:
+        var devOpsOptions = new CommandOptions { SerializeDateAsDollarDate = false };
+        var command = new Command("test", new DataAPIClient(), new[] { devOpsOptions }, null);
+
+        var groups = command.Deserialize<List<PCUGroup>>(json);
+        Assert.Single(groups);
+
+        var group = groups[0];
+        Assert.IsType<PCUGroup>(group);
+        Assert.Equal("org-id", group.OrgId);
+        Assert.Equal(1, group.Min);
+        Assert.Equal(new DateTime(2021, 6, 1, 12, 0, 0, DateTimeKind.Utc), group.CreatedAt);
+        Assert.Equal(AstraDatabaseCloudProvider.AWS, group.CloudProvider);
+
+        var pcutype = group.PCUType;
+        Assert.IsType<PCUType>(pcutype);
+        Assert.Equal("eu-west-1", pcutype.Region);
+        Assert.Equal(AstraDatabaseCloudProvider.AWS, pcutype.CloudProvider);
+
+        var details = pcutype.Details;
+        Assert.IsType<PCUTypeDetails>(details);
+        Assert.Equal(0, details.VCpu);
+        Assert.Equal("mstring", details.Memory);
+    }
+
+    [Fact]
+    public void IncompleteNoDetailsPCUGroupDeserializationTest()
+    {
+        var json = """
+            [
+                {
+                    "uuid": "9aaddbb5-4622-447c-9bc5-b036bb9d7ed8",
+                    "cloudProvider": "AWS",
+                    "region": "us-east-1",
+                    "pcuType": {
+                        "type": "standard",
+                        "region": "eu-west-1",
+                        "provider": "aws"
+                    }
+                }
+            ]
+        """;
+
+        // same deserialization setup as in the devops for AstraDatabasesAdmin:
+        var devOpsOptions = new CommandOptions { SerializeDateAsDollarDate = false };
+        var command = new Command("test", new DataAPIClient(), new[] { devOpsOptions }, null);
+
+        var groups = command.Deserialize<List<PCUGroup>>(json);
+        Assert.Single(groups);
+
+        var pcutype = groups[0].PCUType;
+        Assert.Null(pcutype.Details);
+    }
+
+    [Fact]
+    public void IncompleteNoTypePCUGroupDeserializationTest()
+    {
+        var json = """
+            [
+                {
+                    "uuid": "9aaddbb5-4622-447c-9bc5-b036bb9d7ed8",
+                    "cloudProvider": "AWS",
+                    "region": "us-east-1"
+                }
+            ]
+        """;
+
+        // same deserialization setup as in the devops for AstraDatabasesAdmin:
+        var devOpsOptions = new CommandOptions { SerializeDateAsDollarDate = false };
+        var command = new Command("test", new DataAPIClient(), new[] { devOpsOptions }, null);
+
+        var groups = command.Deserialize<List<PCUGroup>>(json);
+        Assert.Single(groups);
+
+        var pcutype = groups[0].PCUType;
+        Assert.Null(pcutype);
+    }
+}

--- a/test/DataStax.AstraDB.DataApi.UnitTests/PCUGroupDeserializationTests.cs
+++ b/test/DataStax.AstraDB.DataApi.UnitTests/PCUGroupDeserializationTests.cs
@@ -72,12 +72,12 @@ public class PCUGroupDeserializationTests
         Assert.Equal("org-id", group.OrgId);
         Assert.Equal(1, group.Min);
         Assert.Equal(new DateTime(2021, 6, 1, 12, 0, 0, DateTimeKind.Utc), group.CreatedAt);
-        Assert.Equal(AstraDatabaseCloudProvider.AWS, group.CloudProvider);
+        Assert.Equal(CloudProviderType.AWS, group.CloudProvider);
 
         var pcutype = group.PCUType;
         Assert.IsType<PCUType>(pcutype);
         Assert.Equal("eu-west-1", pcutype.Region);
-        Assert.Equal(AstraDatabaseCloudProvider.AWS, pcutype.CloudProvider);
+        Assert.Equal(CloudProviderType.AWS, pcutype.CloudProvider);
 
         var details = pcutype.Details;
         Assert.IsType<PCUTypeDetails>(details);


### PR DESCRIPTION
Fixes #211 .

Additionally,

1. removes the redundant AstraDatabaseCloudProvider, using CloudProviderType consistently everywhere (with case-insensitive deserialization given the variability of the DevOps API responses)
2. moves the following classes to the `DataStax.AstraDB.DataApi.Admin` namespace:

- `RegionInfo`
- `CreateKeyspaceOptions`
- `DoesKeyspaceExistOptions`
- `DropKeyspaceOptions`
- `ListKeyspacesOptions`
