### PR TITLE
Introduce embedding provider switcher and full switch to Voyage AI for CI/CD

### DIFF
--- a/.github/workflows/_test-hcd.yml
+++ b/.github/workflows/_test-hcd.yml
@@ -13,7 +13,7 @@ env:
   AWS_ECR_ROLE_NAME: ${{ secrets.AWS_ECR_ROLE_NAME }}
   AWS_ECR_REPOSITORY: ${{ secrets.AWS_ECR_REPOSITORY }}
   AWS_ECR_REGISTRY: ${{ secrets.AWS_ECR_REGISTRY }}
-  AWS_ECR_HCD_IMAGE_TAG: "1.2.3"
+  AWS_ECR_HCD_IMAGE_TAG: "2.0.6"
 
 jobs:
   test:

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -1,12 +1,12 @@
 services:
   hcd:
-    image: 559669398656.dkr.ecr.us-west-2.amazonaws.com/engops-shared/hcd/prod/hcd:1.2.3
+    image: 559669398656.dkr.ecr.us-west-2.amazonaws.com/engops-shared/hcd/prod/hcd:2.0.6
     networks:
       - stargate
     mem_limit: 2G
     environment:
       - MAX_HEAP_SIZE=1536M
-      - CLUSTER_NAME=hcd-1.2.3-cluster
+      - CLUSTER_NAME=hcd-2.0.6-cluster
       - DS_LICENSE=accept
       - HCD_AUTO_CONF_OFF=xcassandra.yaml
       - JVM_EXTRA_OPTS=-Dcassandra.sai.latest.version=ec
@@ -21,7 +21,7 @@ services:
       retries: 20
 
   data-api:
-    image: stargateio/data-api:v1.0.32
+    image: stargateio/data-api:v1.0.46
     depends_on:
       hcd:
         condition: service_healthy

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/EmbeddingProviderSwitcher.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/EmbeddingProviderSwitcher.cs
@@ -1,0 +1,46 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace DataStax.AstraDB.DataApi.IntegrationTests;
+
+/// <summary>
+/// Static configuration on the embedding provider for all vectorize-related integration testing.
+/// </summary>
+public static class EmbeddingProviderSwitcher {
+
+    /// <summary>
+    /// Embedding provider to use.
+    /// </summary>
+    public const string Provider = "voyageAI";
+    /// <summary>
+    /// Embedding model to use.
+    /// </summary>
+    public const string ModelName = "voyage-2";
+
+    /// <summary>
+    /// A dimension value compatible with the provider/model choice.
+    /// </summary>
+    public const int Dimension = 1024;
+
+    /// <summary>
+    /// Name of the secret in Astra scoped to the DB being used to test.
+    /// </summary>
+    public const string KMSSecretName = "SHARED_SECRET_EMBEDDING_API_KEY_VOYAGEAI";
+    /// <summary>
+    /// Name of the environment variable containing the embedding API key.
+    /// </summary>
+    public const string SecretEnvironmentVariableName = "HEADER_EMBEDDING_API_KEY_VOYAGEAI";
+}

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/TestObjects.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/TestObjects.cs
@@ -91,8 +91,8 @@ public class SimpleObjectWithVectorizeAttribute
 
 [CollectionName("coll_SimpleObjectWithVectorizeShSecret")]
 [CollectionVectorize(
-    Provider = "openai", ModelName = "text-embedding-3-small",
-    AuthenticationPairs = new string[] {"providerKey", "SHARED_SECRET_EMBEDDING_API_KEY_OPENAI"}
+    Provider = "voyageAI", ModelName = "voyage-2",
+    AuthenticationPairs = new string[] {"providerKey", "SHARED_SECRET_EMBEDDING_API_KEY_VOYAGEAI"}
 )]
 public class SimpleObjectWithVectorizeAttributeShSecret
 {
@@ -106,12 +106,12 @@ public class SimpleObjectWithVectorizeAttributeShSecret
 [CollectionName("coll_SimpleObjectWithVectorizeShSecret2A")]
 [CollectionVector(
     SimilarityMetric.Euclidean,
-    123,
+    1024,
     SourceModel="bert"
 )]
 [CollectionVectorize(
-    Provider = "openai", ModelName = "text-embedding-3-small",
-    AuthenticationPairs = new string[] {"providerKey", "SHARED_SECRET_EMBEDDING_API_KEY_OPENAI"}
+    Provider = "voyageAI", ModelName = "voyage-2",
+    AuthenticationPairs = new string[] {"providerKey", "SHARED_SECRET_EMBEDDING_API_KEY_VOYAGEAI"}
 )]
 public class SimpleObjectWithVectorizeAttributeShSecret2A
 {
@@ -123,7 +123,7 @@ public class SimpleObjectWithVectorizeAttributeShSecret2A
 }
 
 [CollectionName("coll_SimpleObjectWithVectorizeHeader")]
-[CollectionVectorize(Provider = "openai", ModelName = "text-embedding-3-small")]
+[CollectionVectorize(Provider = "voyageAI", ModelName = "voyage-2")]
 public class SimpleObjectWithVectorizeAttributeHeader
 {
     [DocumentId]
@@ -279,7 +279,7 @@ public class RowBookVectorizeHeaderBased
 {
     [ColumnPrimaryKey(1)]
     public string Title { get; set; }
-    [ColumnVectorize("openai", "text-embedding-3-small", dimension: 1536)]
+    [ColumnVectorize("voyageAI", "voyage-2", dimension: 1024)]
     public object Author { get; set; }
     [ColumnPrimaryKey(2)]
     public int NumberOfPages { get; set; }
@@ -294,8 +294,8 @@ public class RowBookVectorizeSharedSecret
     [ColumnPrimaryKey(1)]
     public string Title { get; set; }
     [ColumnVectorize(
-        "openai", "text-embedding-3-small", dimension: 1536,
-        authenticationPairs: new string[] {"providerKey", "SHARED_SECRET_EMBEDDING_API_KEY_OPENAI"}
+        "voyageAI", "voyage-2", dimension: 1024,
+        authenticationPairs: new string[] {"providerKey", "SHARED_SECRET_EMBEDDING_API_KEY_VOYAGEAI"}
     )]
     public object Author { get; set; }
     [ColumnPrimaryKey(2)]

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/TestObjects.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/TestObjects.cs
@@ -91,8 +91,8 @@ public class SimpleObjectWithVectorizeAttribute
 
 [CollectionName("coll_SimpleObjectWithVectorizeShSecret")]
 [CollectionVectorize(
-    Provider = "voyageAI", ModelName = "voyage-2",
-    AuthenticationPairs = new string[] {"providerKey", "SHARED_SECRET_EMBEDDING_API_KEY_VOYAGEAI"}
+    Provider = EmbeddingProviderSwitcher.Provider, ModelName = EmbeddingProviderSwitcher.ModelName,
+    AuthenticationPairs = new string[] {"providerKey", EmbeddingProviderSwitcher.KMSSecretName}
 )]
 public class SimpleObjectWithVectorizeAttributeShSecret
 {
@@ -106,12 +106,12 @@ public class SimpleObjectWithVectorizeAttributeShSecret
 [CollectionName("coll_SimpleObjectWithVectorizeShSecret2A")]
 [CollectionVector(
     SimilarityMetric.Euclidean,
-    1024,
+    EmbeddingProviderSwitcher.Dimension,
     SourceModel="bert"
 )]
 [CollectionVectorize(
-    Provider = "voyageAI", ModelName = "voyage-2",
-    AuthenticationPairs = new string[] {"providerKey", "SHARED_SECRET_EMBEDDING_API_KEY_VOYAGEAI"}
+    Provider = EmbeddingProviderSwitcher.Provider, ModelName = EmbeddingProviderSwitcher.ModelName,
+    AuthenticationPairs = new string[] {"providerKey", EmbeddingProviderSwitcher.KMSSecretName}
 )]
 public class SimpleObjectWithVectorizeAttributeShSecret2A
 {
@@ -123,7 +123,7 @@ public class SimpleObjectWithVectorizeAttributeShSecret2A
 }
 
 [CollectionName("coll_SimpleObjectWithVectorizeHeader")]
-[CollectionVectorize(Provider = "voyageAI", ModelName = "voyage-2")]
+[CollectionVectorize(Provider = EmbeddingProviderSwitcher.Provider, ModelName = EmbeddingProviderSwitcher.ModelName)]
 public class SimpleObjectWithVectorizeAttributeHeader
 {
     [DocumentId]
@@ -279,7 +279,7 @@ public class RowBookVectorizeHeaderBased
 {
     [ColumnPrimaryKey(1)]
     public string Title { get; set; }
-    [ColumnVectorize("voyageAI", "voyage-2", dimension: 1024)]
+    [ColumnVectorize(EmbeddingProviderSwitcher.Provider, EmbeddingProviderSwitcher.ModelName, dimension: EmbeddingProviderSwitcher.Dimension)]
     public object Author { get; set; }
     [ColumnPrimaryKey(2)]
     public int NumberOfPages { get; set; }
@@ -294,8 +294,8 @@ public class RowBookVectorizeSharedSecret
     [ColumnPrimaryKey(1)]
     public string Title { get; set; }
     [ColumnVectorize(
-        "voyageAI", "voyage-2", dimension: 1024,
-        authenticationPairs: new string[] {"providerKey", "SHARED_SECRET_EMBEDDING_API_KEY_VOYAGEAI"}
+        EmbeddingProviderSwitcher.Provider, EmbeddingProviderSwitcher.ModelName, dimension: EmbeddingProviderSwitcher.Dimension,
+        authenticationPairs: new string[] {"providerKey", EmbeddingProviderSwitcher.KMSSecretName}
     )]
     public object Author { get; set; }
     [ColumnPrimaryKey(2)]
@@ -311,8 +311,8 @@ public class RowBookVectorizeSharedSecretWithParameters
     [ColumnPrimaryKey(1)]
     public string Title { get; set; }
     [ColumnVectorize(
-        "voyageAI", "voyage-2",
-        authenticationPairs: new string[] { "providerKey", "SHARED_SECRET_EMBEDDING_API_KEY_VOYAGEAI" },
+        EmbeddingProviderSwitcher.Provider, EmbeddingProviderSwitcher.ModelName,
+        authenticationPairs: new string[] { "providerKey", EmbeddingProviderSwitcher.KMSSecretName },
         parameterPairs: new object[] { "autoTruncate", false }
     )]
     public object Author { get; set; }
@@ -842,8 +842,8 @@ public class FakeDocument
 
 [CollectionName("coll_one_embedding_header_test")]
 [CollectionVectorize(
-    "voyageAI",
-    "voyage-2",
+    EmbeddingProviderSwitcher.Provider,
+    EmbeddingProviderSwitcher.ModelName,
     parameterPairs: new object[] { "autoTruncate", false }
 )]
 public class DocumentForEmbeddingHeaderTest
@@ -876,7 +876,7 @@ public class RowForEmbeddingHeaderTest
     [ColumnPrimaryKey(1)]
     public string Id { get; set; }
     [ColumnVectorize(
-        "voyageAI", "voyage-2", dimension: 1024,
+        EmbeddingProviderSwitcher.Provider, EmbeddingProviderSwitcher.ModelName, dimension: EmbeddingProviderSwitcher.Dimension,
         parameterPairs: new object[] { "autoTruncate", false }
     )]
     public object Name { get; set; }

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdditionalCollectionTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdditionalCollectionTests.cs
@@ -552,11 +552,11 @@ public class AdditionalCollectionTests
         }
     }
 
-    // Requires VOYAGE embedding provider
-    [Fact(Skip="Should be run after exporting the environment variable quoted below")]
+    // Requires a certain embedding provider (see EmbeddingProviderSwitcher)
+    [Fact(Skip="Should be run after exporting the environment variable quoted in EmbeddingProviderSwitcher")]
     public async Task Test_CollectionEmbeddingHeaders()
     {
-        var embeddingAPIKey = Environment.GetEnvironmentVariable("HEADER_EMBEDDING_API_KEY_VOYAGEAI") ?? "kaboom";
+        var embeddingAPIKey = Environment.GetEnvironmentVariable(EmbeddingProviderSwitcher.SecretEnvironmentVariableName) ?? "kaboom";
         try
         {
             var collectionCr = await fixture.Database.CreateCollectionAsync<DocumentForEmbeddingHeaderTest>(

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdditionalTableTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdditionalTableTests.cs
@@ -1252,11 +1252,11 @@ public class AdditionalTableTests
         }
     }
 
-    // Requires VOYAGE embedding provider
-    [Fact(Skip="Should be run after exporting the environment variable quoted below")]
+    // Requires a certain embedding provider (see EmbeddingProviderSwitcher)
+    [Fact(Skip="Should be run after exporting the environment variable quoted in EmbeddingProviderSwitcher")]
     public async Task Test_TableEmbeddingHeaders()
     {
-        var embeddingAPIKey = Environment.GetEnvironmentVariable("HEADER_EMBEDDING_API_KEY_VOYAGEAI") ?? "kaboom";
+        var embeddingAPIKey = Environment.GetEnvironmentVariable(EmbeddingProviderSwitcher.SecretEnvironmentVariableName) ?? "kaboom";
         try
         {
             var tableCr = await fixture.Database.CreateTableAsync<RowForEmbeddingHeaderTest>(

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/CollectionFARRCursorTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/CollectionFARRCursorTests.cs
@@ -308,7 +308,8 @@ public class CollectionFARRCursorTests
         await Assert.ThrowsAsync<CommandException>(async () => await cur.ToListAsync());
     }
 
-    [Fact]
+    // TODO: re-enable this test when rerank-override is available in the target Data API version
+    [Fact(Skip="This test is disabled until Rerak-Override is released.")]
     public async Task Test_CollectionVectorFARRRerankOverride()
     {
         var filledCollection = _fixture.FilledVectorCollection;
@@ -358,7 +359,8 @@ public class CollectionFARRCursorTests
         );
     }
 
-    [Fact]
+    // TODO: re-enable this test when rerank-override is available in the target Data API version
+    [Fact(Skip="This test is disabled until Rerak-Override is released.")]
     public async Task Test_CollectionVectorizeFARRRerankOverride()
     {
         var filledCollection = _fixture.FilledVectorizeCollection;

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/DatabaseTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/DatabaseTests.cs
@@ -476,7 +476,7 @@ public class DatabaseTests
     }
 
     [SkipWhenNotAstra]
-    [Fact(Skip="Should be run manually after scoping a certain embedding key to the database with the name in the document class")]
+    [Fact(Skip="Should be run manually after scoping a certain embedding key to the database, see EmbeddingProviderSwitcher")]
     public async Task CreateCollection_WithVectorizeSharedSecret_Typed()
     {
         var collectionName = "coll_SimpleObjectWithVectorizeShSecret";
@@ -494,7 +494,7 @@ public class DatabaseTests
     }
 
     [SkipWhenNotAstra]
-    [Fact(Skip="Should be run manually after scoping a certain embedding key to the database with the name in the document class")]
+    [Fact(Skip="Should be run manually after scoping a certain embedding key to the database, see EmbeddingProviderSwitcher")]
     public async Task CreateCollection_WithVectorizeSharedSecretDoubleAttribute_Typed()
     {
         var collectionName = "coll_SimpleObjectWithVectorizeShSecret2A";
@@ -511,10 +511,10 @@ public class DatabaseTests
         await fixture.Database.DropCollectionAsync(collectionName);
     }
 
-    [Fact(Skip="Should be run after exporting the environment variable quoted below")]
+    [Fact(Skip="Should be run after exporting the environment variable quoted in EmbeddingProviderSwitcher")]
     public async Task CreateGetCollection_WithVectorizeHeader_Typed()
     {
-        var embeddingAPIKey = Environment.GetEnvironmentVariable("HEADER_EMBEDDING_API_KEY_VOYAGEAI") ?? "kaboom";
+        var embeddingAPIKey = Environment.GetEnvironmentVariable(EmbeddingProviderSwitcher.SecretEnvironmentVariableName) ?? "kaboom";
         var headerOptions = new CreateCollectionOptions() { EmbeddingAPIKey = embeddingAPIKey };
         var collectionName = "coll_SimpleObjectWithVectorizeHeader";
         // Signature of overloads mandates that we supply the collection name here. Eeh, I think we can live with that.
@@ -571,7 +571,7 @@ public class DatabaseTests
     }
 
     [SkipWhenNotAstra]
-    [Fact(Skip="Should be run manually after scoping a certain embedding key to the database with the name quoted below")]
+    [Fact(Skip="Should be run manually after scoping a certain embedding key to the database, see EmbeddingProviderSwitcher")]
     public async Task CreateCollection_WithVectorizeSharedSecret_Untyped()
     {
         var collectionName = "collectionVectorizesharedSecret_Untyped";
@@ -579,15 +579,15 @@ public class DatabaseTests
         {
             Vector = new VectorOptions
             {
-                Dimension = 1024,
+                Dimension = EmbeddingProviderSwitcher.Dimension,
                 Metric = SimilarityMetric.DotProduct,
                 Service = new VectorServiceOptions()
                 {
-                    Provider = "voyageAI",
-                    ModelName = "voyage-2",
+                    Provider = EmbeddingProviderSwitcher.Provider,
+                    ModelName = EmbeddingProviderSwitcher.ModelName,
                     Authentication = new Dictionary<string, string>
                     {
-                        { "providerKey", "SHARED_SECRET_EMBEDDING_API_KEY_VOYAGEAI" }
+                        { "providerKey", EmbeddingProviderSwitcher.KMSSecretName }
                     }
                 }
             }
@@ -604,22 +604,22 @@ public class DatabaseTests
         await fixture.Database.DropCollectionAsync(collectionName);
     }
 
-    [Fact(Skip="Should be run after exporting the environment variable quoted below")]
+    [Fact(Skip="Should be run after exporting the environment variable quoted in EmbeddingProviderSwitcher")]
     public async Task CreateGetCollection_WithVectorizeHeader_Untyped()
     {
-        var embeddingAPIKey = Environment.GetEnvironmentVariable("HEADER_EMBEDDING_API_KEY_VOYAGEAI") ?? "kaboom";
+        var embeddingAPIKey = Environment.GetEnvironmentVariable(EmbeddingProviderSwitcher.SecretEnvironmentVariableName) ?? "kaboom";
         var headerOptions = new CreateCollectionOptions() { EmbeddingAPIKey = embeddingAPIKey };
         var collectionName = "collection_WithVectorizeHeader_Untyped";
         var options = new CollectionDefinition
         {
             Vector = new VectorOptions
             {
-                Dimension = 1024,
+                Dimension = EmbeddingProviderSwitcher.Dimension,
                 Metric = SimilarityMetric.DotProduct,
                 Service = new VectorServiceOptions()
                 {
-                    Provider = "voyageAI",
-                    ModelName = "voyage-2",
+                    Provider = EmbeddingProviderSwitcher.Provider,
+                    ModelName = EmbeddingProviderSwitcher.ModelName,
                 }
             }
         };
@@ -808,7 +808,7 @@ public class DatabaseTests
     }
 
     [SkipWhenNotAstra]
-    [Fact(Skip="Should be run manually after scoping a certain embedding key to the database with the name in the row class")]
+    [Fact(Skip="Should be run manually after scoping a certain embedding key to the database, see EmbeddingProviderSwitcher")]
     public async Task CreateTable_WithVectorizeSharedSecret_Typed()
     {
         try
@@ -825,7 +825,7 @@ public class DatabaseTests
     }
 
     [SkipWhenNotAstra]
-    [Fact(Skip="Should be run manually after scoping a certain embedding key to the database with the name in the row class")]
+    [Fact(Skip="Should be run manually after scoping a certain embedding key to the database, see EmbeddingProviderSwitcher")]
     public async Task CreateTable_WithVectorizeSharedSecretWithParameters_Typed()
     {
         try
@@ -841,10 +841,10 @@ public class DatabaseTests
         }
     }
 
-    [Fact(Skip="Should be run after exporting the environment variable quoted below")]
+    [Fact(Skip="Should be run after exporting the environment variable quoted in EmbeddingProviderSwitcher")]
     public async Task CreateGetTable_WithVectorizeHeader_Typed()
     {
-        var embeddingAPIKey = Environment.GetEnvironmentVariable("HEADER_EMBEDDING_API_KEY_VOYAGEAI") ?? "kaboom";
+        var embeddingAPIKey = Environment.GetEnvironmentVariable(EmbeddingProviderSwitcher.SecretEnvironmentVariableName) ?? "kaboom";
         var gtHeaderOptions = new GetTableOptions() { EmbeddingAPIKey = embeddingAPIKey };
         var ctHeaderOptions = new CreateTableOptions() { EmbeddingAPIKey = embeddingAPIKey };
         try
@@ -895,7 +895,7 @@ public class DatabaseTests
     }
 
     [SkipWhenNotAstra]
-    [Fact(Skip="Should be run manually after scoping a certain embedding key to the database with the name quoted below")]
+    [Fact(Skip="Should be run manually after scoping a certain embedding key to the database, see EmbeddingProviderSwitcher")]
     public async Task CreateTable_WithVectorizeSharedSecret_Untyped()
     {
         var tableName = "bookTestTableVectorizeSharedSecret_Untyped";
@@ -904,13 +904,13 @@ public class DatabaseTests
             var createDefinition = new TableDefinition()
                 .AddColumn("Title", DataAPIType.Text())
                 .AddColumn("NumberOfPages", DataAPIType.Int())
-                .AddColumn("Author", DataAPIType.Vectorize(1024, new VectorServiceOptions
+                .AddColumn("Author", DataAPIType.Vectorize(EmbeddingProviderSwitcher.Dimension, new VectorServiceOptions
                 {
-                    Provider = "voyageAI",
-                    ModelName = "voyage-2",
+                    Provider = EmbeddingProviderSwitcher.Provider,
+                    ModelName = EmbeddingProviderSwitcher.ModelName,
                     Authentication = new Dictionary<string, string>
                     {
-                        { "providerKey", "SHARED_SECRET_EMBEDDING_API_KEY_VOYAGEAI" }
+                        { "providerKey", EmbeddingProviderSwitcher.KMSSecretName }
                     }
                 }))
                 .AddCompositePrimaryKey(new [] {"Title", "NumberOfPages"});
@@ -932,7 +932,7 @@ public class DatabaseTests
 
 
     [SkipWhenNotAstra]
-    [Fact(Skip="Should be run manually after scoping a certain embedding key to the database with the name quoted below")]
+    [Fact(Skip="Should be run manually after scoping a certain embedding key to the database, see EmbeddingProviderSwitcher")]
     public async Task CreateTable_WithVectorizeSharedSecretWithParameters_Untyped()
     {
         var tableName = "bookTestTableVeczeShdSecretWParams_Untyped";
@@ -941,13 +941,13 @@ public class DatabaseTests
             var createDefinition = new TableDefinition()
                 .AddColumn("Title", DataAPIType.Text())
                 .AddColumn("NumberOfPages", DataAPIType.Int())
-                .AddColumn("Author", DataAPIType.Vectorize(1024, new VectorServiceOptions
+                .AddColumn("Author", DataAPIType.Vectorize(EmbeddingProviderSwitcher.Dimension, new VectorServiceOptions
                 {
-                    Provider = "voyageAI",
-                    ModelName = "voyage-2",
+                    Provider = EmbeddingProviderSwitcher.Provider,
+                    ModelName = EmbeddingProviderSwitcher.ModelName,
                     Authentication = new Dictionary<string, string>
                     {
-                        { "providerKey", "SHARED_SECRET_EMBEDDING_API_KEY_VOYAGEAI" }
+                        { "providerKey", EmbeddingProviderSwitcher.KMSSecretName }
                     },
                     Parameters = new Dictionary<string, object>
                     {
@@ -971,11 +971,11 @@ public class DatabaseTests
         }
     }
 
-    [Fact(Skip="Should be run after exporting the environment variable quoted below")]
+    [Fact(Skip="Should be run after exporting the environment variable quoted in EmbeddingProviderSwitcher")]
     public async Task CreateGetTable_WithVectorizeHeader_Untyped()
     {
         var tableName = "bookTestTableVectorizeHeader_Untyped";
-        var embeddingAPIKey = Environment.GetEnvironmentVariable("HEADER_EMBEDDING_API_KEY_VOYAGEAI") ?? "kaboom";
+        var embeddingAPIKey = Environment.GetEnvironmentVariable(EmbeddingProviderSwitcher.SecretEnvironmentVariableName) ?? "kaboom";
         var gtHeaderOptions = new GetTableOptions() { EmbeddingAPIKey = embeddingAPIKey };
         var ctHeaderOptions = new CreateTableOptions() { EmbeddingAPIKey = embeddingAPIKey };
         try
@@ -983,10 +983,10 @@ public class DatabaseTests
             var createDefinition = new TableDefinition()
                 .AddColumn("Title", DataAPIType.Text())
                 .AddColumn("NumberOfPages", DataAPIType.Int())
-                .AddColumn("Author", DataAPIType.Vectorize(1024, new VectorServiceOptions
+                .AddColumn("Author", DataAPIType.Vectorize(EmbeddingProviderSwitcher.Dimension, new VectorServiceOptions
                 {
-                    Provider = "voyageAI",
-                    ModelName = "voyage-2",
+                    Provider = EmbeddingProviderSwitcher.Provider,
+                    ModelName = EmbeddingProviderSwitcher.ModelName,
                 }))
                 .AddCompositePrimaryKey(new [] {"Title", "NumberOfPages"});
 
@@ -1007,7 +1007,7 @@ public class DatabaseTests
         }
         finally
         {
-            await fixture.Database.DropTableAsync<RowBookVectorizeHeaderBased>(tableName);
+            await fixture.Database.DropTableAsync(tableName);
         }
     }
 

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/DatabaseTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/DatabaseTests.cs
@@ -476,7 +476,7 @@ public class DatabaseTests
     }
 
     [SkipWhenNotAstra]
-    [Fact(Skip="Should be run manually after scoping a certain OpenAI key to the database with the name quoted below")]
+    [Fact(Skip="Should be run manually after scoping a certain embedding key to the database with the name in the document class")]
     public async Task CreateCollection_WithVectorizeSharedSecret_Typed()
     {
         var collectionName = "coll_SimpleObjectWithVectorizeShSecret";
@@ -494,7 +494,7 @@ public class DatabaseTests
     }
 
     [SkipWhenNotAstra]
-    [Fact(Skip="Should be run manually after scoping a certain OpenAI key to the database with the name quoted below")]
+    [Fact(Skip="Should be run manually after scoping a certain embedding key to the database with the name in the document class")]
     public async Task CreateCollection_WithVectorizeSharedSecretDoubleAttribute_Typed()
     {
         var collectionName = "coll_SimpleObjectWithVectorizeShSecret2A";
@@ -571,7 +571,7 @@ public class DatabaseTests
     }
 
     [SkipWhenNotAstra]
-    [Fact(Skip="Should be run manually after scoping a certain OpenAI key to the database with the name quoted below")]
+    [Fact(Skip="Should be run manually after scoping a certain embedding key to the database with the name quoted below")]
     public async Task CreateCollection_WithVectorizeSharedSecret_Untyped()
     {
         var collectionName = "collectionVectorizesharedSecret_Untyped";
@@ -808,7 +808,7 @@ public class DatabaseTests
     }
 
     [SkipWhenNotAstra]
-    [Fact(Skip="Should be run manually after scoping a certain OpenAI key to the database with the name quoted in RowBookVectorizeSharedSecret")]
+    [Fact(Skip="Should be run manually after scoping a certain embedding key to the database with the name in the row class")]
     public async Task CreateTable_WithVectorizeSharedSecret_Typed()
     {
         try
@@ -825,7 +825,7 @@ public class DatabaseTests
     }
 
     [SkipWhenNotAstra]
-    [Fact(Skip="Should be run manually after scoping a certain OpenAI key to the database with the name quoted in RowBookVectorizeSharedSecretWithParameters")]
+    [Fact(Skip="Should be run manually after scoping a certain embedding key to the database with the name in the row class")]
     public async Task CreateTable_WithVectorizeSharedSecretWithParameters_Typed()
     {
         try
@@ -895,7 +895,7 @@ public class DatabaseTests
     }
 
     [SkipWhenNotAstra]
-    [Fact(Skip="Should be run manually after scoping a certain OpenAI key to the database with the name quoted below")]
+    [Fact(Skip="Should be run manually after scoping a certain embedding key to the database with the name quoted below")]
     public async Task CreateTable_WithVectorizeSharedSecret_Untyped()
     {
         var tableName = "bookTestTableVectorizeSharedSecret_Untyped";
@@ -932,7 +932,7 @@ public class DatabaseTests
 
 
     [SkipWhenNotAstra]
-    [Fact(Skip="Should be run manually after scoping a certain OpenAI key to the database with the name quoted below")]
+    [Fact(Skip="Should be run manually after scoping a certain embedding key to the database with the name quoted below")]
     public async Task CreateTable_WithVectorizeSharedSecretWithParameters_Untyped()
     {
         var tableName = "bookTestTableVeczeShdSecretWParams_Untyped";

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/DatabaseTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/DatabaseTests.cs
@@ -514,7 +514,7 @@ public class DatabaseTests
     [Fact(Skip="Should be run after exporting the environment variable quoted below")]
     public async Task CreateGetCollection_WithVectorizeHeader_Typed()
     {
-        var embeddingAPIKey = Environment.GetEnvironmentVariable("HEADER_EMBEDDING_API_KEY_OPENAI") ?? "kaboom";
+        var embeddingAPIKey = Environment.GetEnvironmentVariable("HEADER_EMBEDDING_API_KEY_VOYAGEAI") ?? "kaboom";
         var headerOptions = new CreateCollectionOptions() { EmbeddingAPIKey = embeddingAPIKey };
         var collectionName = "coll_SimpleObjectWithVectorizeHeader";
         // Signature of overloads mandates that we supply the collection name here. Eeh, I think we can live with that.
@@ -579,15 +579,15 @@ public class DatabaseTests
         {
             Vector = new VectorOptions
             {
-                Dimension = 1536,
+                Dimension = 1024,
                 Metric = SimilarityMetric.DotProduct,
                 Service = new VectorServiceOptions()
                 {
-                    Provider = "openai",
-                    ModelName = "text-embedding-3-small",
+                    Provider = "voyageAI",
+                    ModelName = "voyage-2",
                     Authentication = new Dictionary<string, string>
                     {
-                        { "providerKey", "SHARED_SECRET_EMBEDDING_API_KEY_OPENAI" }
+                        { "providerKey", "SHARED_SECRET_EMBEDDING_API_KEY_VOYAGEAI" }
                     }
                 }
             }
@@ -607,19 +607,19 @@ public class DatabaseTests
     [Fact(Skip="Should be run after exporting the environment variable quoted below")]
     public async Task CreateGetCollection_WithVectorizeHeader_Untyped()
     {
-        var embeddingAPIKey = Environment.GetEnvironmentVariable("HEADER_EMBEDDING_API_KEY_OPENAI") ?? "kaboom";
+        var embeddingAPIKey = Environment.GetEnvironmentVariable("HEADER_EMBEDDING_API_KEY_VOYAGEAI") ?? "kaboom";
         var headerOptions = new CreateCollectionOptions() { EmbeddingAPIKey = embeddingAPIKey };
         var collectionName = "collection_WithVectorizeHeader_Untyped";
         var options = new CollectionDefinition
         {
             Vector = new VectorOptions
             {
-                Dimension = 1536,
+                Dimension = 1024,
                 Metric = SimilarityMetric.DotProduct,
                 Service = new VectorServiceOptions()
                 {
-                    Provider = "openai",
-                    ModelName = "text-embedding-3-small",
+                    Provider = "voyageAI",
+                    ModelName = "voyage-2",
                 }
             }
         };
@@ -844,7 +844,7 @@ public class DatabaseTests
     [Fact(Skip="Should be run after exporting the environment variable quoted below")]
     public async Task CreateGetTable_WithVectorizeHeader_Typed()
     {
-        var embeddingAPIKey = Environment.GetEnvironmentVariable("HEADER_EMBEDDING_API_KEY_OPENAI") ?? "kaboom";
+        var embeddingAPIKey = Environment.GetEnvironmentVariable("HEADER_EMBEDDING_API_KEY_VOYAGEAI") ?? "kaboom";
         var gtHeaderOptions = new GetTableOptions() { EmbeddingAPIKey = embeddingAPIKey };
         var ctHeaderOptions = new CreateTableOptions() { EmbeddingAPIKey = embeddingAPIKey };
         try
@@ -904,13 +904,13 @@ public class DatabaseTests
             var createDefinition = new TableDefinition()
                 .AddColumn("Title", DataAPIType.Text())
                 .AddColumn("NumberOfPages", DataAPIType.Int())
-                .AddColumn("Author", DataAPIType.Vectorize(1536, new VectorServiceOptions
+                .AddColumn("Author", DataAPIType.Vectorize(1024, new VectorServiceOptions
                 {
-                    Provider = "openai",
-                    ModelName = "text-embedding-3-small",
+                    Provider = "voyageAI",
+                    ModelName = "voyage-2",
                     Authentication = new Dictionary<string, string>
                     {
-                        { "providerKey", "SHARED_SECRET_EMBEDDING_API_KEY_OPENAI" }
+                        { "providerKey", "SHARED_SECRET_EMBEDDING_API_KEY_VOYAGEAI" }
                     }
                 }))
                 .AddCompositePrimaryKey(new [] {"Title", "NumberOfPages"});
@@ -975,7 +975,7 @@ public class DatabaseTests
     public async Task CreateGetTable_WithVectorizeHeader_Untyped()
     {
         var tableName = "bookTestTableVectorizeHeader_Untyped";
-        var embeddingAPIKey = Environment.GetEnvironmentVariable("HEADER_EMBEDDING_API_KEY_OPENAI") ?? "kaboom";
+        var embeddingAPIKey = Environment.GetEnvironmentVariable("HEADER_EMBEDDING_API_KEY_VOYAGEAI") ?? "kaboom";
         var gtHeaderOptions = new GetTableOptions() { EmbeddingAPIKey = embeddingAPIKey };
         var ctHeaderOptions = new CreateTableOptions() { EmbeddingAPIKey = embeddingAPIKey };
         try
@@ -983,10 +983,10 @@ public class DatabaseTests
             var createDefinition = new TableDefinition()
                 .AddColumn("Title", DataAPIType.Text())
                 .AddColumn("NumberOfPages", DataAPIType.Int())
-                .AddColumn("Author", DataAPIType.Vectorize(1536, new VectorServiceOptions
+                .AddColumn("Author", DataAPIType.Vectorize(1024, new VectorServiceOptions
                 {
-                    Provider = "openai",
-                    ModelName = "text-embedding-3-small",
+                    Provider = "voyageAI",
+                    ModelName = "voyage-2",
                 }))
                 .AddCompositePrimaryKey(new [] {"Title", "NumberOfPages"});
 
@@ -1007,7 +1007,7 @@ public class DatabaseTests
         }
         finally
         {
-            await fixture.Database.DropTableAsync<RowBookVectorizeHeaderBased>();
+            await fixture.Database.DropTableAsync<RowBookVectorizeHeaderBased>(tableName);
         }
     }
 


### PR DESCRIPTION
This PR introduces a clean, centralized layer to switch the choice of the secret-requiring embedding provider for use in the CI/CD testing. Now it's VoyageAI.

(Apart from the nvidia embedding provider, that is, which is still hardcoded for some Astra-only tests and does not require secrets to be provided, via kms or otherwise)
