### PR TITLE
Enable creation of nonvector DBs

### DIFF
--- a/src/DataStax.AstraDB.DataApi/Admin/CreateDatabaseOptions.cs
+++ b/src/DataStax.AstraDB.DataApi/Admin/CreateDatabaseOptions.cs
@@ -66,7 +66,7 @@ public class CreateDatabaseOptions : BlockingCommandOptions
     public int CapacityUnits { get; set; } = DefaultCapacityUnits;
 
     /// <summary>
-    /// Database type (defaults to "vector").
+    /// Database type: "vector" (default) / "nonvector".
     /// </summary>
     public string DBType { get; set; } = DefaultDBType;
 

--- a/src/DataStax.AstraDB.DataApi/Admin/CreateDatabaseOptions.cs
+++ b/src/DataStax.AstraDB.DataApi/Admin/CreateDatabaseOptions.cs
@@ -17,6 +17,7 @@
 using DataStax.AstraDB.DataApi.Core;
 using System.Text.Json.Serialization;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace DataStax.AstraDB.DataApi.Admin;
 
@@ -25,9 +26,10 @@ namespace DataStax.AstraDB.DataApi.Admin;
 /// </summary>
 public class CreateDatabaseOptions : BlockingCommandOptions
 {
+    private static readonly string[] NonVectorDBTypeStrings = { "nonvector", "non-vector", "non vector", "non_vector" };
     private const string DefaultTier = "serverless";
     private const int DefaultCapacityUnits = 1;
-    private const string DefaultDbType = "vector";
+    private const string DefaultDBType = "vector";
 
     /// <summary>
     /// Name of the database to be created.
@@ -66,7 +68,7 @@ public class CreateDatabaseOptions : BlockingCommandOptions
     /// <summary>
     /// Database type (defaults to "vector").
     /// </summary>
-    public string DBType { get; set; } = DefaultDbType;
+    public string DBType { get; set; } = DefaultDBType;
 
     /// <summary>
     /// PCU group ID to use for provisioning the database. Optional.
@@ -79,7 +81,10 @@ public class CreateDatabaseOptions : BlockingCommandOptions
 
         payload["tier"] = Tier;
         payload["capacityUnits"] = CapacityUnits;
-        payload["dbType"] = DBType;
+        // explicit null DBType is passed into the payload (the DevOps API will error at that)
+        if (DBType == null || !NonVectorDBTypeStrings.Contains(DBType.ToLower())) {
+            payload["dbType"] = DBType;
+        }
         if ( Name != null )
         {
             payload["name"] = Name;

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdminTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/AdminTests.cs
@@ -18,6 +18,7 @@ using DataStax.AstraDB.DataApi.Admin;
 using DataStax.AstraDB.DataApi.Core;
 using DataStax.AstraDB.DataApi.Core.Results;
 using DataStax.AstraDB.DataApi.IntegrationTests.Fixtures;
+using System.Net.Http;
 using Xunit;
 
 namespace DataStax.AstraDB.DataApi.IntegrationTests;
@@ -704,6 +705,27 @@ public class AdminTests
             || dbStatus2 == AstraDatabaseStatus.PENDING);
     }
 
+    // dotnet test --filter FullyQualifiedName=DataStax.AstraDB.DataApi.IntegrationTests.AdminTests.CreateDatabaseNullDBTypeAsync
+    [Fact(Skip = AdminCollection.SkipMessage)]
+    public async Task CreateDatabaseNullDBTypeAsync()
+    {
+        var dbName = "test-db-create-nulldbtype-async-x";
+        var creationOptions = new CreateDatabaseOptions() {
+            Name = dbName,
+            CloudProvider = CloudProviderType.AWS,
+            Region = "us-west-2",
+            waitForCompletion = false,
+            DBType = null,
+        };
+
+        var astraAdmin = fixture.Client.GetAstraDatabasesAdmin();
+
+        await Assert.ThrowsAsync<HttpRequestException>(async () =>
+        {
+            await astraAdmin.CreateDatabaseAsync(creationOptions);
+        });
+    }
+
     // dotnet test --filter FullyQualifiedName=DataStax.AstraDB.DataApi.IntegrationTests.AdminTests.CreateDatabaseBlockingSync
     [Fact(Skip = AdminCollection.SkipMessage)]
     public void CreateDatabaseBlockingSync()
@@ -802,6 +824,35 @@ public class AdminTests
             Region = "us-west-2",
             waitForCompletion = false,
             PCUGroupId = "8424aa7c-a26b-44cc-8ae3-c65aec7a184f",
+        };
+
+        var astraAdmin = fixture.Client.GetAstraDatabasesAdmin();
+
+        var dbAdmin = await astraAdmin.CreateDatabaseAsync(creationOptions);
+
+        var dbStatus = await astraAdmin.GetDatabaseStatusAsync(dbAdmin.Id);
+        Assert.True(dbStatus == AstraDatabaseStatus.ASSOCIATING
+            || dbStatus == AstraDatabaseStatus.INITIALIZING
+            || dbStatus == AstraDatabaseStatus.PENDING);
+
+        var dbAdmin2 = astraAdmin.GetDatabaseAdmin(dbAdmin.GetAPIEndpoint());
+        var dbStatus2 = await astraAdmin.GetDatabaseStatusAsync(dbAdmin2.Id);
+        Assert.True(dbStatus2 == AstraDatabaseStatus.ASSOCIATING
+            || dbStatus2 == AstraDatabaseStatus.INITIALIZING
+            || dbStatus2 == AstraDatabaseStatus.PENDING);
+    }
+
+    // dotnet test --filter FullyQualifiedName=DataStax.AstraDB.DataApi.IntegrationTests.AdminTests.CreateNonvectorDatabaseNonblockingAsync
+    [Fact(Skip = AdminCollection.SkipMessage)]
+    public async Task CreateNonvectorDatabaseNonblockingAsync()
+    {
+        var dbName = "test-nonvector-db-create-async-x";
+        var creationOptions = new CreateDatabaseOptions() {
+            Name = dbName,
+            CloudProvider = CloudProviderType.AWS,
+            Region = "us-west-2",
+            waitForCompletion = false,
+            DBType = "NonVector",
         };
 
         var astraAdmin = fixture.Client.GetAstraDatabasesAdmin();


### PR DESCRIPTION
Passing `DBType="nonvector"` when building the CreateDatabaseOptions becomes the way to create a nonvector database.

This follows the specs discussed and agreed-upon among the client team.

_As with most admin methods, this has been extensively tested, but manually - the related tests are disabled from CI/CD._