### PR TITLE
Tables: complete CQL data type coverage in and out of the Primary Key

### DIFF
--- a/src/DataStax.AstraDB.DataApi/SerDes/TableInsertManyResultConverter.cs
+++ b/src/DataStax.AstraDB.DataApi/SerDes/TableInsertManyResultConverter.cs
@@ -118,7 +118,6 @@ internal class TableInsertManyResultConverter : JsonConverter<TableInsertManyRes
                 case "text":
                     return element.GetString()!;
                 case "bigint":
-                case "varint":
                     return element.GetInt64();
                 case "blob":
                     return Convert.FromBase64String(element.GetString()!);
@@ -131,6 +130,7 @@ internal class TableInsertManyResultConverter : JsonConverter<TableInsertManyRes
                     return DateTime.Parse(element.GetString()!).Date;
 #endif
                 case "decimal":
+                case "varint":
                     return element.GetDecimal();
                 case "double":
                     if (element.ValueKind == JsonValueKind.String) // ugly but TableInsertManyResultConverter won't exist in the future anyway
@@ -171,7 +171,7 @@ internal class TableInsertManyResultConverter : JsonConverter<TableInsertManyRes
                 case "timestamp":
                     return DateTime.Parse(element.GetString()!, null, DateTimeStyles.RoundtripKind);
                 case "tinyint":
-                    return (byte)(element.GetInt16());
+                    return element.GetSByte();
                 case "uuid":
                     return Guid.Parse(element.GetString()!);
                 case "vector":

--- a/src/DataStax.AstraDB.DataApi/SerDes/TableInsertManyResultConverter.cs
+++ b/src/DataStax.AstraDB.DataApi/SerDes/TableInsertManyResultConverter.cs
@@ -153,6 +153,12 @@ internal class TableInsertManyResultConverter : JsonConverter<TableInsertManyRes
                     return element.GetBoolean();
                 case "timestamp":
                     return DateTime.Parse(element.GetString()!);
+                case "date":
+#if NET6_0_OR_GREATER
+                    return DateOnly.Parse(element.GetString()!);
+#else
+                    return DateTime.Parse(element.GetString()!).Date;
+#endif
                 case "uuid":
                     return Guid.Parse(element.GetString()!);
                 default:

--- a/src/DataStax.AstraDB.DataApi/SerDes/TableInsertManyResultConverter.cs
+++ b/src/DataStax.AstraDB.DataApi/SerDes/TableInsertManyResultConverter.cs
@@ -17,6 +17,7 @@
 using DataStax.AstraDB.DataApi.Tables;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -113,16 +114,22 @@ internal class TableInsertManyResultConverter : JsonConverter<TableInsertManyRes
         {
             switch (schema.Type)
             {
-                case "text":
                 case "ascii":
+                case "text":
                     return element.GetString()!;
-                case "vector":
-                    var floatList = element.Deserialize<List<float>>(options)!;
-                    return floatList.ToArray();
-                case "int":
-                    return element.GetInt32();
                 case "bigint":
+                case "varint":
                     return element.GetInt64();
+                case "blob":
+                    return Convert.FromBase64String(element.GetString()!);
+                case "boolean":
+                    return element.GetBoolean();
+                case "date":
+#if NET6_0_OR_GREATER
+                    return DateOnly.Parse(element.GetString()!);
+#else
+                    return DateTime.Parse(element.GetString()!).Date;
+#endif
                 case "decimal":
                     return element.GetDecimal();
                 case "double":
@@ -149,18 +156,27 @@ internal class TableInsertManyResultConverter : JsonConverter<TableInsertManyRes
                         };
                     }
                     return element.GetSingle();
-                case "boolean":
-                    return element.GetBoolean();
-                case "timestamp":
-                    return DateTime.Parse(element.GetString()!);
-                case "date":
+                case "inet":
+                    return System.Net.IPAddress.Parse(element.GetString()!);
+                case "int":
+                    return element.GetInt32();
+                case "smallint":
+                    return (short)(element.GetInt16());
+                case "time":
 #if NET6_0_OR_GREATER
-                    return DateOnly.Parse(element.GetString()!);
+                    return TimeOnly.Parse(element.GetString()!);
 #else
-                    return DateTime.Parse(element.GetString()!).Date;
+                    return DateTime.Parse(element.GetString()!).TimeOfDay;
 #endif
+                case "timestamp":
+                    return DateTime.Parse(element.GetString()!, null, DateTimeStyles.RoundtripKind);
+                case "tinyint":
+                    return (byte)(element.GetInt16());
                 case "uuid":
                     return Guid.Parse(element.GetString()!);
+                case "vector":
+                    var floatList = element.Deserialize<List<float>>(options)!;
+                    return floatList.ToArray();
                 default:
                     throw new JsonException($"Unsupported schema type: {schema.Type}");
             }

--- a/src/DataStax.AstraDB.DataApi/Tables/Table.cs
+++ b/src/DataStax.AstraDB.DataApi/Tables/Table.cs
@@ -772,6 +772,15 @@ public class Table<T> where T : class
                 if (element.ValueKind == JsonValueKind.String && TimeOnly.TryParse(element.GetString(), CultureInfo.InvariantCulture, out var to))
                     return to;
                 break;
+#else
+            case "date":
+                if (element.ValueKind == JsonValueKind.String && DateTime.TryParse(element.GetString(), CultureInfo.InvariantCulture, DateTimeStyles.None, out var d))
+                    return d.Date;   // strip time component; returns a DateTime at midnight
+                break;
+            case "time":
+                if (element.ValueKind == JsonValueKind.String && TimeSpan.TryParse(element.GetString(), CultureInfo.InvariantCulture, out var to))
+                    return to;       // TimeSpan is the standard pre-net6 substitute for time-of-day
+                break;
 #endif
             case "timestamp":
                 if (element.ValueKind == JsonValueKind.String && DateTime.TryParse(element.GetString(), null, DateTimeStyles.RoundtripKind, out var dt))

--- a/src/DataStax.AstraDB.DataApi/Utils/TypeUtilities.cs
+++ b/src/DataStax.AstraDB.DataApi/Utils/TypeUtilities.cs
@@ -293,17 +293,22 @@ public class DataAPIType
     public static DataAPIType Inet() => new DataAPIType("inet");
     /// <summary>Creates an int column type.</summary>
     public static DataAPIType Int() => new DataAPIType("int");
-
+    /// <summary>Creates a smallint column type.</summary>
+    public static DataAPIType SmallInt() => new DataAPIType("smallint");
     /// <summary>Creates a text column type.</summary>
     public static DataAPIType Text() => new DataAPIType("text");
     /// <summary>Creates a time column type.</summary>
     public static DataAPIType Time() => new DataAPIType("time");
-    /// <summary>Creates a time uuid column type.</summary>
-    public static DataAPIType TimeUuid() => new DataAPIType("timeuuid");
     /// <summary>Creates a timestamp column type.</summary>
     public static DataAPIType Timestamp() => new DataAPIType("timestamp");
+    /// <summary>Creates a time uuid column type.</summary>
+    public static DataAPIType TimeUuid() => new DataAPIType("timeuuid");
+    /// <summary>Creates a tinyint column type.</summary>
+    public static DataAPIType TinyInt() => new DataAPIType("tinyint");
     /// <summary>Creates a uuid column type.</summary>
     public static DataAPIType Uuid() => new DataAPIType("uuid");
+    /// <summary>Creates a varint column type.</summary>
+    public static DataAPIType VarInt() => new DataAPIType("varint");
 
     /// <summary>Creates a list column type with the specified element type.</summary>
     public static DataAPIType List(DataAPIType valueType) => new ListDataAPIType(valueType);

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/TestObjects.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/TestObjects.cs
@@ -281,7 +281,6 @@ public class RowWithAllTypesInPK
     public float TheFloat { get; set; }
     [ColumnPrimaryKey(9)]
     public System.Net.IPAddress TheInet { get; set; }
-
     [ColumnPrimaryKey(10)]
     public int TheInt { get; set; }
     [ColumnPrimaryKey(11)]
@@ -302,6 +301,32 @@ public class RowWithAllTypesInPK
     public float[] TheVector { get; set; }
     //
     public string TheNonPKValue { get; set; }
+}
+
+[TableName("insertAllTypesOutsidePKRowsTest")]
+public class RowWithAllTypesOutsidePK
+{
+    [ColumnPrimaryKey]
+    public string ThePK { get; set; }
+    // non-PK values
+    public string? TheAscii { get; set; }
+    public long? TheBigInt { get; set; }
+    public DateOnly? TheDateOnly { get; set; }
+    public bool? TheBoolean { get; set; }
+    public byte[]? TheBlob { get; set; }
+    public decimal? TheDecimal { get; set; }
+    public double? TheDouble { get; set; }
+    public float? TheFloat { get; set; }
+    public System.Net.IPAddress? TheInet { get; set; }
+    public int? TheInt { get; set; }
+    public short? TheSmallint { get; set; }
+    public string? TheText { get; set; }
+    public TimeOnly? TheTime { get; set; }
+    public DateTime? TheTimestamp { get; set; }
+    public byte? TheTinyint { get; set; }
+    public Guid? TheUuid { get; set; }
+    public long? TheVarint { get; set; }
+    public float[]? TheVector { get; set; }
 }
 
 [TableName("bookTestTableVectorize")]

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/TestObjects.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/TestObjects.cs
@@ -263,9 +263,45 @@ public class RowBook
 [TableName("insertAllTypesInPKRowsTest")]
 public class RowWithAllTypesInPK
 {
-    [ColumnPrimaryKey]
+    [ColumnPrimaryKey(1)]
+    public string TheAscii { get; set; }
+    [ColumnPrimaryKey(2)]
+    public long TheBigInt { get; set; }
+    [ColumnPrimaryKey(3)]
     public DateOnly TheDateOnly { get; set; }
+    [ColumnPrimaryKey(4)]
+    public bool TheBoolean { get; set; }
+    [ColumnPrimaryKey(5)]
+    public byte[] TheBlob { get; set; }
+    [ColumnPrimaryKey(6)]
+    public decimal TheDecimal { get; set; }
+    [ColumnPrimaryKey(7)]
+    public double TheDouble { get; set; }
+    [ColumnPrimaryKey(8)]
+    public float TheFloat { get; set; }
+    [ColumnPrimaryKey(9)]
+    public System.Net.IPAddress TheInet { get; set; }
+
+    [ColumnPrimaryKey(10)]
+    public int TheInt { get; set; }
+    [ColumnPrimaryKey(11)]
+    public short TheSmallint { get; set; }
+    [ColumnPrimaryKey(12)]
     public string TheText { get; set; }
+    [ColumnPrimaryKey(13)]
+    public TimeOnly TheTime { get; set; }
+    [ColumnPrimaryKey(14)]
+    public DateTime TheTimestamp { get; set; }
+    [ColumnPrimaryKey(15)]
+    public byte TheTinyint { get; set; }
+    [ColumnPrimaryKey(16)]
+    public Guid TheUuid { get; set; }
+    [ColumnPrimaryKey(17)]
+    public long TheVarint { get; set; }
+    [ColumnPrimaryKey(18)]
+    public float[] TheVector { get; set; }
+    //
+    public string TheNonPKValue { get; set; }
 }
 
 [TableName("bookTestTableVectorize")]

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/TestObjects.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/TestObjects.cs
@@ -329,6 +329,13 @@ public class RowWithAllTypesOutsidePK
     public float[]? TheVector { get; set; }
 }
 
+public class RowWithTimeUUID
+{
+    [ColumnPrimaryKey]
+    public string id { get; set; }
+    public TimeUuid the_tuid { get; set; }
+}
+
 [TableName("bookTestTableVectorize")]
 public class RowBookVectorize
 {

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/TestObjects.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/TestObjects.cs
@@ -292,11 +292,11 @@ public class RowWithAllTypesInPK
     [ColumnPrimaryKey(14)]
     public DateTime TheTimestamp { get; set; }
     [ColumnPrimaryKey(15)]
-    public byte TheTinyint { get; set; }
+    public sbyte TheTinyint { get; set; }
     [ColumnPrimaryKey(16)]
     public Guid TheUuid { get; set; }
     [ColumnPrimaryKey(17)]
-    public long TheVarint { get; set; }
+    public decimal TheVarint { get; set; }
     [ColumnPrimaryKey(18)]
     public float[] TheVector { get; set; }
     //
@@ -323,9 +323,9 @@ public class RowWithAllTypesOutsidePK
     public string? TheText { get; set; }
     public TimeOnly? TheTime { get; set; }
     public DateTime? TheTimestamp { get; set; }
-    public byte? TheTinyint { get; set; }
+    public sbyte? TheTinyint { get; set; }
     public Guid? TheUuid { get; set; }
-    public long? TheVarint { get; set; }
+    public decimal? TheVarint { get; set; }
     public float[]? TheVector { get; set; }
 }
 

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/TestObjects.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/TestObjects.cs
@@ -260,6 +260,14 @@ public class RowBook
     public float Rating { get; set; }
 }
 
+[TableName("insertAllTypesInPKRowsTest")]
+public class RowWithAllTypesInPK
+{
+    [ColumnPrimaryKey]
+    public DateOnly TheDateOnly { get; set; }
+    public string TheText { get; set; }
+}
+
 [TableName("bookTestTableVectorize")]
 public class RowBookVectorize
 {

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/TableTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/TableTests.cs
@@ -141,9 +141,9 @@ public class TableTests
                 2026, 7, 17, 12, 34, 56, 789,
                 DateTimeKind.Utc
             );
-            var theTinyint = (byte)(16);
+            var theTinyint = (sbyte)(16);
             var theUuid = Guid.Parse("63f4f459-1bba-48ee-9151-197cd545a911");
-            var theVarint = 8192;
+            var theVarint = 81928192m;
             var theVector = new float[] { 0.01f, -0.02f };
             var row1 = new RowWithAllTypesInPK()
             {
@@ -244,9 +244,9 @@ public class TableTests
                 2026, 7, 17, 12, 34, 56, 789,
                 DateTimeKind.Utc
             );
-            var theTinyint = (byte)(16);
+            var theTinyint = (sbyte)(16);
             var theUuid = Guid.Parse("63f4f459-1bba-48ee-9151-197cd545a911");
-            var theVarint = 8192;
+            var theVarint = 81928192m;
             var theVector = new float[] { 0.01f, -0.02f };
             var row1 = new RowWithAllTypesOutsidePK()
             {
@@ -355,6 +355,173 @@ public class TableTests
         }
     }
 
+    [Fact]
+    public async Task InsertAllTypesOutsidePKRowsUntyped()
+    {
+        try
+        {
+            var tableDefinition = new TableDefinition()
+                .AddColumn("ThePK", DataAPIType.Text())
+                // ALL NON-PK COLUMNS HERE
+                .AddColumn("TheAscii", DataAPIType.Ascii())
+                .AddColumn("TheBigInt", DataAPIType.BigInt())
+                .AddColumn("TheDateOnly", DataAPIType.Date())
+                .AddColumn("TheBoolean", DataAPIType.Boolean())
+                .AddColumn("TheBlob", DataAPIType.Blob())
+                .AddColumn("TheDecimal", DataAPIType.Decimal())
+                .AddColumn("TheDouble", DataAPIType.Double())
+                .AddColumn("TheFloat", DataAPIType.Float())
+                .AddColumn("TheInet", DataAPIType.Inet())
+                .AddColumn("TheInt", DataAPIType.Int())
+                .AddColumn("TheSmallint", DataAPIType.SmallInt())
+                .AddColumn("TheText", DataAPIType.Text())
+                .AddColumn("TheTime", DataAPIType.Time())
+                .AddColumn("TheTimestamp", DataAPIType.Timestamp())
+                .AddColumn("TheTinyint", DataAPIType.TinyInt())
+                .AddColumn("TheUuid", DataAPIType.Uuid())
+                .AddColumn("TheVarint", DataAPIType.VarInt())
+                .AddColumn("TheVector", DataAPIType.Vector(2))
+                .AddCompositePrimaryKey(new string[] { "ThePK" }
+            );
+            var table = await fixture.Database.CreateTableAsync(
+                "insertAllTypesOutsidePKRowsUntypedTest",
+                tableDefinition
+            );
+
+            // ALL NON-PK VALUE VAR NAMES HERE
+            var theAscii = "my ascii";
+            var theBigInt = 123456789L;
+            var theDateOnly = DateOnly.Parse("2026-07-16");
+            var theBoolean = true;
+            var theBlob = Encoding.ASCII.GetBytes("my blob.");
+            var theDecimal = 12.3456m;
+            var theDouble = 12.3456d;
+            var theFloat = 12.34f;
+            var theInet = IPAddress.Parse("10.1.1.10");
+            var theInt = 4096;
+            var theSmallint = (short)(12);
+            var theText = "my text";
+            var theTime = TimeOnly.Parse("11:22:33.456");
+            var theTimestamp = new DateTime(
+                2026, 7, 17, 12, 34, 56, 789,
+                DateTimeKind.Utc
+            );
+            var theTinyint = (sbyte)(16);
+            var theUuid = Guid.Parse("63f4f459-1bba-48ee-9151-197cd545a911");
+            var theVarint = 81928192m;
+            var theVector = new float[] { 0.01f, -0.02f };
+            var row1 = new Row()
+            {
+                { "ThePK", "row with values" },
+                { "TheAscii", theAscii },
+                { "TheBigInt", theBigInt },
+                { "TheDateOnly", theDateOnly },
+                { "TheBoolean", theBoolean },
+                { "TheBlob", theBlob },
+                { "TheDecimal", theDecimal },
+                { "TheDouble", theDouble },
+                { "TheFloat", theFloat },
+                { "TheInet", theInet },
+                { "TheInt", theInt },
+                { "TheSmallint", theSmallint },
+                { "TheText", theText },
+                { "TheTime", theTime },
+                { "TheTimestamp", theTimestamp },
+                { "TheTinyint", theTinyint },
+                { "TheUuid", theUuid },
+                { "TheVarint", theVarint },
+                { "TheVector", theVector },
+            };
+            var rowN = new Row()
+            {
+                { "ThePK", "row with nulls" },
+                { "TheAscii", null },
+                { "TheBigInt", null },
+                { "TheDateOnly", null },
+                { "TheBoolean", null },
+                { "TheBlob", null },
+                { "TheDecimal", null },
+                { "TheDouble", null },
+                { "TheFloat", null },
+                { "TheInet", null },
+                { "TheInt", null },
+                { "TheSmallint", null },
+                { "TheText", null },
+                { "TheTime", null },
+                { "TheTimestamp", null },
+                { "TheTinyint", null },
+                { "TheUuid", null },
+                { "TheVarint", null },
+                { "TheVector", null },
+            };
+            var rows = new List<Row> { row1, rowN };
+            var result = await table.InsertManyAsync(rows);
+            Assert.Equal(rows.Count, result.InsertedCount);
+            Assert.Equal(rows[0]["ThePK"], result.InsertedIdTuples[0][0]);
+
+            var builder = Builders<Row>.TableFilter;
+
+            // read back and verify everything matches. 1: row with values
+            var filter1 = builder.Eq("ThePK", "row with values");
+            var readRow1 = await table.FindOneAsync(filter1);
+            Assert.NotNull(readRow1);
+            Assert.Equal(row1["ThePK"], readRow1["ThePK"]);
+            Assert.Equal(row1["TheAscii"], readRow1["TheAscii"]);
+            Assert.Equal(row1["TheBigInt"], readRow1["TheBigInt"]);
+            Assert.Equal(row1["TheDateOnly"], readRow1["TheDateOnly"]);
+            Assert.Equal(row1["TheBoolean"], readRow1["TheBoolean"]);
+            Assert.Equal(row1["TheBlob"], readRow1["TheBlob"]);
+            Assert.Equal(row1["TheDecimal"], readRow1["TheDecimal"]);
+            Assert.Equal(row1["TheDouble"], readRow1["TheDouble"]);
+            Assert.Equal(row1["TheFloat"], readRow1["TheFloat"]);
+            Assert.Equal(row1["TheInet"], readRow1["TheInet"]);
+            Assert.Equal(row1["TheInt"], readRow1["TheInt"]);
+            Assert.Equal(row1["TheSmallint"], readRow1["TheSmallint"]);
+            Assert.Equal(row1["TheText"], readRow1["TheText"]);
+            Assert.Equal(row1["TheTime"], readRow1["TheTime"]);
+            Assert.Equal(row1["TheTimestamp"], readRow1["TheTimestamp"]);
+            Assert.Equal(row1["TheTinyint"], readRow1["TheTinyint"]);
+            Assert.Equal(row1["TheUuid"], readRow1["TheUuid"]);
+            Assert.Equal(row1["TheVarint"], readRow1["TheVarint"]);
+            // Must tolerate float-precision rounding for "TheVector":
+            float[] row1Vec = (float [])row1["TheVector"];
+            float[] readRow1Vec = ((System.Text.Json.JsonElement)readRow1["TheVector"])
+                .EnumerateArray()
+                .Select(e => e.GetSingle())
+                .ToArray();
+            Assert.True(Math.Abs(row1Vec[0] - readRow1Vec[0]) < 1e-6);
+            Assert.True(Math.Abs(row1Vec[1] - readRow1Vec[1]) < 1e-6);
+
+            // read back and verify everything matches. 2: row with nulls
+            var filterN = builder.Eq("ThePK", "row with nulls");
+            var readRowN = await table.FindOneAsync(filterN);
+            Assert.NotNull(readRowN);
+            Assert.Equal(rowN["ThePK"], readRowN["ThePK"]);
+            Assert.Equal(rowN["TheAscii"], readRowN["TheAscii"]);
+            Assert.Equal(rowN["TheBigInt"], readRowN["TheBigInt"]);
+            Assert.Equal(rowN["TheDateOnly"], readRowN["TheDateOnly"]);
+            Assert.Equal(rowN["TheBoolean"], readRowN["TheBoolean"]);
+            Assert.Equal(rowN["TheBlob"], readRowN["TheBlob"]);
+            Assert.Equal(rowN["TheDecimal"], readRowN["TheDecimal"]);
+            Assert.Equal(rowN["TheDouble"], readRowN["TheDouble"]);
+            Assert.Equal(rowN["TheFloat"], readRowN["TheFloat"]);
+            Assert.Equal(rowN["TheInet"], readRowN["TheInet"]);
+            Assert.Equal(rowN["TheInt"], readRowN["TheInt"]);
+            Assert.Equal(rowN["TheSmallint"], readRowN["TheSmallint"]);
+            Assert.Equal(rowN["TheText"], readRowN["TheText"]);
+            Assert.Equal(rowN["TheTime"], readRowN["TheTime"]);
+            Assert.Equal(rowN["TheTimestamp"], readRowN["TheTimestamp"]);
+            Assert.Equal(rowN["TheTinyint"], readRowN["TheTinyint"]);
+            Assert.Equal(rowN["TheUuid"], readRowN["TheUuid"]);
+            Assert.Equal(rowN["TheVarint"], readRowN["TheVarint"]);
+            Assert.Equal(rowN["TheVector"], readRowN["TheVector"]);
+        }
+        finally
+        {
+            await fixture.Database.DropTableAsync("insertAllTypesOutsidePKRowsUntypedTest");
+        }
+    }
+
     /* IMPORTANT: run these two tests after CQL manual setup (and cleanup afterwards)
         -- Manual test setup:
         CREATE TABLE table_with_timeuuid (id TEXT PRIMARY KEY, the_tuid TIMEUUID);
@@ -376,8 +543,7 @@ public class TableTests
         Assert.Equal(new TimeUuid(new Guid("183f8300-8458-11f1-8202-41b65ed1b8e7")), readRow.the_tuid);
     }
 
-    // [Fact(Skip="Requires manual CQL setup, this test to be launched manually.")]
-    [Fact]
+    [Fact(Skip="Requires manual CQL setup, this test to be launched manually.")]
     public async Task ReadTimeUUIDUntyped()
     {
         var table = fixture.Database.GetTable("table_with_timeuuid");

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/TableTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/TableTests.cs
@@ -74,6 +74,29 @@ public class TableTests
     }
 
     [Fact]
+    public async Task InsertAllTypesInPKRows()
+    {
+        try
+        {
+            var table = await fixture.Database.CreateTableAsync<RowWithAllTypesInPK>();
+            var theDateOnly = DateOnly.Parse("2026-07-16");;
+            var row1 = new RowWithAllTypesInPK()
+            {
+                TheDateOnly = theDateOnly,
+                TheText = "Test Row",
+            };
+            var rows = new List<RowWithAllTypesInPK> { row1 };
+            var result = await table.InsertManyAsync(rows);
+            Assert.Equal(rows.Count, result.InsertedCount);
+            Assert.Equal(rows[0].TheDateOnly, result.InsertedIdTuples[0][0]);
+        }
+        finally
+        {
+            await fixture.Database.DropTableAsync<RowWithAllTypesInPK>();
+        }
+    }
+
+    [Fact]
     [SkipWhenNotAstra] // TODO why is this not throwing on HCD in CI? It throws just fine when running on HCD locally
     public async Task InsertManyCommandOptions()
     {

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/TableTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/TableTests.cs
@@ -197,6 +197,165 @@ public class TableTests
     }
 
     [Fact]
+    public async Task InsertAllTypesOutsidePKRowsTyped()
+    {
+        try
+        {
+            var tableDefinition = new TableDefinition()
+                .AddColumn("ThePK", DataAPIType.Text())
+                // ALL NON-PK COLUMNS HERE
+                .AddColumn("TheAscii", DataAPIType.Ascii())
+                .AddColumn("TheBigInt", DataAPIType.BigInt())
+                .AddColumn("TheDateOnly", DataAPIType.Date())
+                .AddColumn("TheBoolean", DataAPIType.Boolean())
+                .AddColumn("TheBlob", DataAPIType.Blob())
+                .AddColumn("TheDecimal", DataAPIType.Decimal())
+                .AddColumn("TheDouble", DataAPIType.Double())
+                .AddColumn("TheFloat", DataAPIType.Float())
+                .AddColumn("TheInet", DataAPIType.Inet())
+                .AddColumn("TheInt", DataAPIType.Int())
+                .AddColumn("TheSmallint", DataAPIType.SmallInt())
+                .AddColumn("TheText", DataAPIType.Text())
+                .AddColumn("TheTime", DataAPIType.Time())
+                .AddColumn("TheTimestamp", DataAPIType.Timestamp())
+                .AddColumn("TheTinyint", DataAPIType.TinyInt())
+                .AddColumn("TheUuid", DataAPIType.Uuid())
+                .AddColumn("TheVarint", DataAPIType.VarInt())
+                .AddColumn("TheVector", DataAPIType.Vector(2))
+                .AddCompositePrimaryKey(new string[] { "ThePK" }
+            );
+            var table = await fixture.Database.CreateTableAsync<RowWithAllTypesOutsidePK>(tableDefinition);
+
+            // ALL NON-PK VALUE VAR NAMES HERE
+            var theAscii = "my ascii";
+            var theBigInt = 123456789L;
+            var theDateOnly = DateOnly.Parse("2026-07-16");
+            var theBoolean = true;
+            var theBlob = Encoding.ASCII.GetBytes("my blob.");
+            var theDecimal = 12.3456m;
+            var theDouble = 12.3456d;
+            var theFloat = 12.34f;
+            var theInet = IPAddress.Parse("10.1.1.10");
+            var theInt = 4096;
+            var theSmallint = (short)(12);
+            var theText = "my text";
+            var theTime = TimeOnly.Parse("11:22:33.456");
+            var theTimestamp = new DateTime(
+                2026, 7, 17, 12, 34, 56, 789,
+                DateTimeKind.Utc
+            );
+            var theTinyint = (byte)(16);
+            var theUuid = Guid.Parse("63f4f459-1bba-48ee-9151-197cd545a911");
+            var theVarint = 8192;
+            var theVector = new float[] { 0.01f, -0.02f };
+            var row1 = new RowWithAllTypesOutsidePK()
+            {
+                ThePK = "row with values",
+                // ALL NON-PK COLUMN VALUE SETTINGS TO ROW HERE
+                TheAscii = theAscii,
+                TheBigInt = theBigInt,
+                TheDateOnly = theDateOnly,
+                TheBoolean = theBoolean,
+                TheBlob = theBlob,
+                TheDecimal = theDecimal,
+                TheDouble = theDouble,
+                TheFloat = theFloat,
+                TheInet = theInet,
+                TheInt = theInt,
+                TheSmallint = theSmallint,
+                TheText = theText,
+                TheTime = theTime,
+                TheTimestamp = theTimestamp,
+                TheTinyint = theTinyint,
+                TheUuid = theUuid,
+                TheVarint = theVarint,
+                TheVector = theVector,
+            };
+            var rowN = new RowWithAllTypesOutsidePK()
+            {
+                ThePK = "row with nulls",
+                // ALL NON-PK COLUMN VALUE SETTINGS TO ROW HERE
+                TheAscii = null,
+                TheBigInt = null,
+                TheDateOnly = null,
+                TheBoolean = null,
+                TheBlob = null,
+                TheDecimal = null,
+                TheDouble = null,
+                TheFloat = null,
+                TheInet = null,
+                TheInt = null,
+                TheSmallint = null,
+                TheText = null,
+                TheTime = null,
+                TheTimestamp = null,
+                TheTinyint = null,
+                TheUuid = null,
+                TheVarint = null,
+                TheVector = null,
+            };
+            var rows = new List<RowWithAllTypesOutsidePK> { row1, rowN };
+            var result = await table.InsertManyAsync(rows);
+            Assert.Equal(rows.Count, result.InsertedCount);
+            Assert.Equal(rows[0].ThePK, result.InsertedIdTuples[0][0]);
+
+            var builder = Builders<RowWithAllTypesOutsidePK>.TableFilter;
+
+            // read back and verify everything matches. 1: row with values
+            var filter1 = builder.Eq(r => r.ThePK, "row with values");
+            var readRow1 = await table.FindOneAsync(filter1);
+            Assert.NotNull(readRow1);
+            Assert.Equal(row1.ThePK, readRow1.ThePK);
+            Assert.Equal(row1.TheAscii, readRow1.TheAscii);
+            Assert.Equal(row1.TheBigInt, readRow1.TheBigInt);
+            Assert.Equal(row1.TheDateOnly, readRow1.TheDateOnly);
+            Assert.Equal(row1.TheBoolean, readRow1.TheBoolean);
+            Assert.Equal(row1.TheBlob, readRow1.TheBlob);
+            Assert.Equal(row1.TheDecimal, readRow1.TheDecimal);
+            Assert.Equal(row1.TheDouble, readRow1.TheDouble);
+            Assert.Equal(row1.TheFloat, readRow1.TheFloat);
+            Assert.Equal(row1.TheInet, readRow1.TheInet);
+            Assert.Equal(row1.TheInt, readRow1.TheInt);
+            Assert.Equal(row1.TheSmallint, readRow1.TheSmallint);
+            Assert.Equal(row1.TheText, readRow1.TheText);
+            Assert.Equal(row1.TheTime, readRow1.TheTime);
+            Assert.Equal(row1.TheTimestamp, readRow1.TheTimestamp);
+            Assert.Equal(row1.TheTinyint, readRow1.TheTinyint);
+            Assert.Equal(row1.TheUuid, readRow1.TheUuid);
+            Assert.Equal(row1.TheVarint, readRow1.TheVarint);
+            Assert.Equal(row1.TheVector, readRow1.TheVector);
+
+            // read back and verify everything matches. 2: row with nulls
+            var filterN = builder.Eq(r => r.ThePK, "row with nulls");
+            var readRowN = await table.FindOneAsync(filterN);
+            Assert.NotNull(readRowN);
+            Assert.Equal(rowN.ThePK, readRowN.ThePK);
+            Assert.Equal(rowN.TheAscii, readRowN.TheAscii);
+            Assert.Equal(rowN.TheBigInt, readRowN.TheBigInt);
+            Assert.Equal(rowN.TheDateOnly, readRowN.TheDateOnly);
+            Assert.Equal(rowN.TheBoolean, readRowN.TheBoolean);
+            Assert.Equal(rowN.TheBlob, readRowN.TheBlob);
+            Assert.Equal(rowN.TheDecimal, readRowN.TheDecimal);
+            Assert.Equal(rowN.TheDouble, readRowN.TheDouble);
+            Assert.Equal(rowN.TheFloat, readRowN.TheFloat);
+            Assert.Equal(rowN.TheInet, readRowN.TheInet);
+            Assert.Equal(rowN.TheInt, readRowN.TheInt);
+            Assert.Equal(rowN.TheSmallint, readRowN.TheSmallint);
+            Assert.Equal(rowN.TheText, readRowN.TheText);
+            Assert.Equal(rowN.TheTime, readRowN.TheTime);
+            Assert.Equal(rowN.TheTimestamp, readRowN.TheTimestamp);
+            Assert.Equal(rowN.TheTinyint, readRowN.TheTinyint);
+            Assert.Equal(rowN.TheUuid, readRowN.TheUuid);
+            Assert.Equal(rowN.TheVarint, readRowN.TheVarint);
+            Assert.Equal(rowN.TheVector, readRowN.TheVector);
+        }
+        finally
+        {
+            await fixture.Database.DropTableAsync<RowWithAllTypesOutsidePK>();
+        }
+    }
+
+    [Fact]
     [SkipWhenNotAstra] // TODO why is this not throwing on HCD in CI? It throws just fine when running on HCD locally
     public async Task InsertManyCommandOptions()
     {

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/TableTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/TableTests.cs
@@ -19,6 +19,7 @@ using DataStax.AstraDB.DataApi.Core.Query;
 using DataStax.AstraDB.DataApi.Core.Results;
 using DataStax.AstraDB.DataApi.IntegrationTests.Fixtures;
 using DataStax.AstraDB.DataApi.Tables;
+using DataStax.AstraDB.DataApi.Utils;
 using Microsoft.VisualBasic;
 using System.Net;
 using System.Text;
@@ -78,17 +79,116 @@ public class TableTests
     {
         try
         {
-            var table = await fixture.Database.CreateTableAsync<RowWithAllTypesInPK>();
-            var theDateOnly = DateOnly.Parse("2026-07-16");;
+            var tableDefinition = new TableDefinition()
+                // ALL PK COLUMNS HERE
+                .AddColumn("TheAscii", DataAPIType.Ascii())
+                .AddColumn("TheBigInt", DataAPIType.BigInt())
+                .AddColumn("TheDateOnly", DataAPIType.Date())
+                .AddColumn("TheBoolean", DataAPIType.Boolean())
+                .AddColumn("TheBlob", DataAPIType.Blob())
+                .AddColumn("TheDecimal", DataAPIType.Decimal())
+                .AddColumn("TheDouble", DataAPIType.Double())
+                .AddColumn("TheFloat", DataAPIType.Float())
+                .AddColumn("TheInet", DataAPIType.Inet())
+                .AddColumn("TheInt", DataAPIType.Int())
+                .AddColumn("TheSmallint", DataAPIType.SmallInt())
+                .AddColumn("TheText", DataAPIType.Text())
+                .AddColumn("TheTime", DataAPIType.Time())
+                .AddColumn("TheTimestamp", DataAPIType.Timestamp())
+                .AddColumn("TheTinyint", DataAPIType.TinyInt())
+                .AddColumn("TheUuid", DataAPIType.Uuid())
+                .AddColumn("TheVarint", DataAPIType.VarInt())
+                .AddColumn("TheVector", DataAPIType.Vector(2))
+                .AddColumn("TheNonPKValue", DataAPIType.Text())
+                .AddCompositePrimaryKey(new string[] {
+                    // ALL PK COLUMN NAMES HERE
+                    "TheAscii",
+                    "TheBigInt",
+                    "TheDateOnly",
+                    "TheBoolean",
+                    "TheBlob",
+                    "TheDecimal",
+                    "TheDouble",
+                    "TheFloat",
+                    "TheInet",
+                    "TheInt",
+                    "TheSmallint",
+                    "TheText",
+                    "TheTime",
+                    "TheTimestamp",
+                    "TheTinyint",
+                    "TheUuid",
+                    "TheVarint",
+                    "TheVector",
+                });
+            var table = await fixture.Database.CreateTableAsync<RowWithAllTypesInPK>(tableDefinition);
+
+            // ALL PK VALUE VAR NAMES HERE
+            var theAscii = "my ascii";
+            var theBigInt = 123456789L;
+            var theDateOnly = DateOnly.Parse("2026-07-16");
+            var theBoolean = true;
+            var theBlob = Encoding.ASCII.GetBytes("my blob.");
+            var theDecimal = 12.3456m;
+            var theDouble = 12.3456d;
+            var theFloat = 12.34f;
+            var theInet = IPAddress.Parse("10.1.1.10");
+            var theInt = 4096;
+            var theSmallint = (short)(12);
+            var theText = "my text";
+            var theTime = TimeOnly.Parse("11:22:33.456");
+            var theTimestamp = new DateTime(
+                2026, 7, 17, 12, 34, 56, 789,
+                DateTimeKind.Utc
+            );
+            var theTinyint = (byte)(16);
+            var theUuid = Guid.Parse("63f4f459-1bba-48ee-9151-197cd545a911");
+            var theVarint = 8192;
+            var theVector = new float[] { 0.01f, -0.02f };
             var row1 = new RowWithAllTypesInPK()
             {
+                // ALL PK COLUMN VALUE SETTINGS TO ROW HERE
+                TheAscii = theAscii,
+                TheBigInt = theBigInt,
                 TheDateOnly = theDateOnly,
-                TheText = "Test Row",
+                TheBoolean = theBoolean,
+                TheBlob = theBlob,
+                TheDecimal = theDecimal,
+                TheDouble = theDouble,
+                TheFloat = theFloat,
+                TheInet = theInet,
+                TheInt = theInt,
+                TheSmallint = theSmallint,
+                TheText = theText,
+                TheTime = theTime,
+                TheTimestamp = theTimestamp,
+                TheTinyint = theTinyint,
+                TheUuid = theUuid,
+                TheVarint = theVarint,
+                TheVector = theVector,
+                TheNonPKValue = "Test Row",
             };
             var rows = new List<RowWithAllTypesInPK> { row1 };
             var result = await table.InsertManyAsync(rows);
             Assert.Equal(rows.Count, result.InsertedCount);
-            Assert.Equal(rows[0].TheDateOnly, result.InsertedIdTuples[0][0]);
+            Assert.Equal(rows[0].TheAscii, result.InsertedIdTuples[0][0]);
+            Assert.Equal(rows[0].TheBigInt, result.InsertedIdTuples[0][1]);
+            Assert.Equal(rows[0].TheDateOnly, result.InsertedIdTuples[0][2]);
+            Assert.Equal(rows[0].TheBoolean, result.InsertedIdTuples[0][3]);
+            Assert.Equal(rows[0].TheBlob, result.InsertedIdTuples[0][4]);
+            Assert.Equal(rows[0].TheDecimal, result.InsertedIdTuples[0][5]);
+            Assert.Equal(rows[0].TheDouble, result.InsertedIdTuples[0][6]);
+            Assert.Equal(rows[0].TheFloat, result.InsertedIdTuples[0][7]);
+            Assert.Equal(rows[0].TheInet, result.InsertedIdTuples[0][8]);
+            Assert.Equal(rows[0].TheInt, result.InsertedIdTuples[0][9]);
+            Assert.Equal(rows[0].TheSmallint, result.InsertedIdTuples[0][10]);
+            Assert.Equal(rows[0].TheText, result.InsertedIdTuples[0][11]);
+            Assert.Equal(rows[0].TheTime, result.InsertedIdTuples[0][12]);
+            Assert.Equal(rows[0].TheTimestamp, result.InsertedIdTuples[0][13]);
+            Assert.Equal(rows[0].TheTinyint, result.InsertedIdTuples[0][14]);
+            Assert.Equal(rows[0].TheUuid, result.InsertedIdTuples[0][15]);
+            Assert.Equal(rows[0].TheVarint, result.InsertedIdTuples[0][16]);
+            Assert.Equal(rows[0].TheVector, result.InsertedIdTuples[0][17]);
         }
         finally
         {

--- a/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/TableTests.cs
+++ b/test/DataStax.AstraDB.DataApi.IntegrationTests/Tests/TableTests.cs
@@ -355,6 +355,38 @@ public class TableTests
         }
     }
 
+    /* IMPORTANT: run these two tests after CQL manual setup (and cleanup afterwards)
+        -- Manual test setup:
+        CREATE TABLE table_with_timeuuid (id TEXT PRIMARY KEY, the_tuid TIMEUUID);
+        INSERT INTO table_with_timeuuid (id , the_tuid ) VALUES ('0', 183f8300-8458-11f1-8202-41b65ed1b8e7);
+
+        -- Verify with:
+        -- SELECT * FROM table_with_timeuuid;
+
+        -- Finally execute this:
+        -- DROP TABLE table_with_timeuuid;
+    */
+    [Fact(Skip="Requires manual CQL setup, this test to be launched manually.")]
+    public async Task ReadTimeUUIDTyped()
+    {
+        var table = fixture.Database.GetTable<RowWithTimeUUID>("table_with_timeuuid");
+        var readRow = await table.FindOneAsync();
+        Assert.NotNull(readRow);
+        Assert.Equal("0", readRow.id);
+        Assert.Equal(new TimeUuid(new Guid("183f8300-8458-11f1-8202-41b65ed1b8e7")), readRow.the_tuid);
+    }
+
+    // [Fact(Skip="Requires manual CQL setup, this test to be launched manually.")]
+    [Fact]
+    public async Task ReadTimeUUIDUntyped()
+    {
+        var table = fixture.Database.GetTable("table_with_timeuuid");
+        var readRow = await table.FindOneAsync();
+        Assert.NotNull(readRow);
+        Assert.Equal("0", readRow["id"]);
+        Assert.Equal(new TimeUuid(new Guid("183f8300-8458-11f1-8202-41b65ed1b8e7")), readRow["the_tuid"]);
+    }
+
     [Fact]
     [SkipWhenNotAstra] // TODO why is this not throwing on HCD in CI? It throws just fine when running on HCD locally
     public async Task InsertManyCommandOptions()


### PR DESCRIPTION
Some less used CQL data types (dateonly; tinyint; inet, etc) were not processed correctly when part of the primary key for tables as part of the returned 'inserted ids'.
Some were not even explicitly taken into account by the deserialization process for row (= outside of the 'inserted id', i.e. on the general table reads), something that is visible behaviour for _untyped_ table reads.

This PR ensures a consistent treatment of all CQL data types that can be part of the primary key, and adds extensive testing to that end.
Incidentally, (manual, cql-driven) testing of the timeuuid case is also added.